### PR TITLE
✨ [FEATURE] #13 - 게시글 등록 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	//jwt 사용 0.12.3 버전 사용
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/example/mody/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/mody/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -3,7 +3,11 @@ package com.example.mody.domain.auth.jwt;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import com.example.mody.domain.auth.security.CustomUserDetails;
+import com.example.mody.domain.member.service.MemberCommandService;
+import com.example.mody.domain.member.service.MemberQueryService;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -35,6 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final JwtProvider jwtProvider;
 	private final MemberRepository memberRepository;
 	private final ObjectMapper objectMapper;
+	private final MemberQueryService memberQueryService;
 
 	@Override
 	protected void doFilterInternal(
@@ -49,7 +54,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 			// 만약 토큰이 있다면
 			if (token != null) {
-				// 토큰 검증 및 추출
+
+				/*
+
 				String providerId = jwtProvider.validateTokenAndGetSubject(token);
 				// findByProviderId로 Member 찾기
 				Member member = memberRepository.findByProviderId(providerId)
@@ -64,6 +71,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 					null,
 					List.of(new SimpleGrantedAuthority(member.getRole().toString()))
 				);
+				*/
+
+				// 토큰 검증 및 추출
+				String payload = jwtProvider.validateTokenAndGetSubject(token);
+				Member member = memberQueryService.findMemberById(Long.parseLong(payload));
+				CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+				Authentication authentication = new UsernamePasswordAuthenticationToken(
+						customUserDetails,
+						null,
+						List.of(new SimpleGrantedAuthority(member.getRole().toString()))
+				);
+
+
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			}
 			filterChain.doFilter(request, response);

--- a/src/main/java/com/example/mody/domain/auth/security/CustomUserDetails.java
+++ b/src/main/java/com/example/mody/domain/auth/security/CustomUserDetails.java
@@ -60,4 +60,8 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    public Member getMember(){
+        return this.member;
+    }
 }

--- a/src/main/java/com/example/mody/domain/backupimage/dto/request/BackupFileRequest.java
+++ b/src/main/java/com/example/mody/domain/backupimage/dto/request/BackupFileRequest.java
@@ -1,0 +1,35 @@
+package com.example.mody.domain.backupimage.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class BackupFileRequest {
+
+    @Schema(
+            description = "파일명",
+            example = "test.jpg"
+    )
+    @NotBlank(message = "파일명 입력은 필수입니다.")
+    private String fileName;
+
+    @Schema(
+            description = "파일 크기. 단위는 KB",
+            example = "200"
+    )
+    @NotBlank(message = "파일 크기 입력은 필수입니다.")
+    @Positive(message = "파일 크기는 음수일 수 없습니다.")
+    private Long fileSize;
+
+
+    @Schema(
+            description = "s3 URI",
+            example = "https://mody-s3-bucket.s3.ap-northeast-2.amazonaws.com/filea8500f7a-c902-4f64-b605-7bc6247b4e75]"
+    )
+    @NotBlank(message = "파일 주소 입력은 필수입니다.")
+    private String s3Url;
+}

--- a/src/main/java/com/example/mody/domain/backupimage/entity/BackupFile.java
+++ b/src/main/java/com/example/mody/domain/backupimage/entity/BackupFile.java
@@ -1,0 +1,29 @@
+package com.example.mody.domain.backupimage.entity;
+
+import com.example.mody.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class BackupFile extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "backup_image_id")
+    private Long id;
+
+    private String fileName;
+    private Long fileSize;
+    private String s3Url;
+
+    public BackupFile(String fileName, Long fileSize, String s3Url){
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.s3Url = s3Url;
+    }
+
+}

--- a/src/main/java/com/example/mody/domain/backupimage/repository/BackupFileRepository.java
+++ b/src/main/java/com/example/mody/domain/backupimage/repository/BackupFileRepository.java
@@ -1,0 +1,9 @@
+package com.example.mody.domain.backupimage.repository;
+
+import com.example.mody.domain.backupimage.entity.BackupFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BackupFileRepository extends JpaRepository<BackupFile, Long> {
+}

--- a/src/main/java/com/example/mody/domain/backupimage/service/BackupFileService.java
+++ b/src/main/java/com/example/mody/domain/backupimage/service/BackupFileService.java
@@ -1,0 +1,21 @@
+package com.example.mody.domain.backupimage.service;
+
+import com.example.mody.domain.backupimage.dto.request.BackupFileRequest;
+import com.example.mody.domain.backupimage.entity.BackupFile;
+import com.example.mody.domain.backupimage.repository.BackupFileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BackupFileService {
+    private final BackupFileRepository backupFileRepository;
+
+    public void saveBackupFile(BackupFileRequest backupFileRequest){
+        BackupFile backupFile = new BackupFile(backupFileRequest.getFileName(),
+                backupFileRequest.getFileSize(),
+                backupFileRequest.getS3Url());
+
+        backupFileRepository.save(backupFile);
+    }
+}

--- a/src/main/java/com/example/mody/domain/bodytype/entity/BodyType.java
+++ b/src/main/java/com/example/mody/domain/bodytype/entity/BodyType.java
@@ -1,0 +1,23 @@
+package com.example.mody.domain.bodytype.entity;
+
+import com.example.mody.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "body_type")
+public class BodyType extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "body_type_id")
+    private Long id;
+
+    @Column(columnDefinition = "varchar(30)", nullable = false)
+    private String name;
+
+}

--- a/src/main/java/com/example/mody/domain/bodytype/entity/MemberBodyType.java
+++ b/src/main/java/com/example/mody/domain/bodytype/entity/MemberBodyType.java
@@ -1,0 +1,27 @@
+package com.example.mody.domain.bodytype.entity;
+
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "member_body_type")
+@Getter
+public class MemberBodyType extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_body_type_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "body_type_id", nullable = false)
+    private BodyType bodyType;
+
+    @Column(length = 2000)
+    private String content;
+}

--- a/src/main/java/com/example/mody/domain/bodytype/repository/BodyTypeRepository.java
+++ b/src/main/java/com/example/mody/domain/bodytype/repository/BodyTypeRepository.java
@@ -1,0 +1,9 @@
+package com.example.mody.domain.bodytype.repository;
+
+import com.example.mody.domain.bodytype.entity.BodyType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BodyTypeRepository extends JpaRepository<BodyType, Long> {
+}

--- a/src/main/java/com/example/mody/domain/bodytype/repository/MemberBodyTypeRepository.java
+++ b/src/main/java/com/example/mody/domain/bodytype/repository/MemberBodyTypeRepository.java
@@ -1,0 +1,13 @@
+package com.example.mody.domain.bodytype.repository;
+
+import com.example.mody.domain.bodytype.entity.MemberBodyType;
+import com.example.mody.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberBodyTypeRepository extends JpaRepository<MemberBodyType, Long> {
+    Optional<MemberBodyType> findTopByMemberOrderByCreatedAt(Member member);
+}

--- a/src/main/java/com/example/mody/domain/bodytype/service/BodyTypeService.java
+++ b/src/main/java/com/example/mody/domain/bodytype/service/BodyTypeService.java
@@ -1,0 +1,28 @@
+package com.example.mody.domain.bodytype.service;
+
+import com.example.mody.domain.bodytype.entity.BodyType;
+import com.example.mody.domain.bodytype.entity.MemberBodyType;
+import com.example.mody.domain.bodytype.repository.BodyTypeRepository;
+import com.example.mody.domain.bodytype.repository.MemberBodyTypeRepository;
+import com.example.mody.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class BodyTypeService {
+    private final BodyTypeRepository bodyTypeRepository;
+    private final MemberBodyTypeRepository memberBodyTypeRepository;
+
+    /**
+     * 유저의 가장 최근 체형 분석 결과의 체형 타입을 반환하는 메서드
+     * @param member 체형 타입을 조회할 유저
+     * @return 마지막 체형 분석이 존재하지 않을 경우 empty Optional을 반환함.
+     */
+    public Optional<BodyType> findLastBodyType(Member member){
+        Optional<MemberBodyType> optionalMemberBodyType =  memberBodyTypeRepository.findTopByMemberOrderByCreatedAt(member);
+        return optionalMemberBodyType.map(MemberBodyType::getBodyType);
+    }
+}

--- a/src/main/java/com/example/mody/domain/exception/BodyTypeException.java
+++ b/src/main/java/com/example/mody/domain/exception/BodyTypeException.java
@@ -1,0 +1,10 @@
+package com.example.mody.domain.exception;
+
+import com.example.mody.global.common.exception.RestApiException;
+import com.example.mody.global.common.exception.code.BaseCodeInterface;
+
+public class BodyTypeException extends RestApiException {
+    public BodyTypeException(BaseCodeInterface errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/mody/domain/exception/PostException.java
+++ b/src/main/java/com/example/mody/domain/exception/PostException.java
@@ -1,0 +1,10 @@
+package com.example.mody.domain.exception;
+
+import com.example.mody.global.common.exception.RestApiException;
+import com.example.mody.global.common.exception.code.BaseCodeInterface;
+
+public class PostException extends RestApiException {
+    public PostException(BaseCodeInterface errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/mody/domain/member/entity/Member.java
+++ b/src/main/java/com/example/mody/domain/member/entity/Member.java
@@ -1,7 +1,11 @@
 package com.example.mody.domain.member.entity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.example.mody.domain.bodytype.entity.MemberBodyType;
+import jakarta.persistence.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -10,14 +14,6 @@ import com.example.mody.domain.member.enums.Role;
 import com.example.mody.domain.member.enums.Status;
 import com.example.mody.global.common.base.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,6 +34,9 @@ public class Member extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "member_id")
 	private Long id;
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.ALL)
+	private List<MemberBodyType> memberBodyType = new ArrayList<>();
 
 	private String providerId;  // OAuth2 제공자의 고유 ID
 

--- a/src/main/java/com/example/mody/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/mody/domain/member/service/MemberQueryService.java
@@ -1,0 +1,7 @@
+package com.example.mody.domain.member.service;
+
+import com.example.mody.domain.member.entity.Member;
+
+public interface MemberQueryService {
+    Member findMemberById(Long memberId);
+}

--- a/src/main/java/com/example/mody/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/member/service/MemberQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package com.example.mody.domain.member.service;
+
+import com.example.mody.domain.exception.MemberException;
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.domain.member.repository.MemberRepository;
+import com.example.mody.global.common.exception.code.status.MemberErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberQueryServiceImpl implements MemberQueryService{
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/constant/PostConstant.java
+++ b/src/main/java/com/example/mody/domain/post/constant/PostConstant.java
@@ -1,0 +1,5 @@
+package com.example.mody.domain.post.constant;
+
+public class PostConstant {
+    public static final int POST_CONTENT_LIMIT = 1000;
+}

--- a/src/main/java/com/example/mody/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/mody/domain/post/controller/PostController.java
@@ -1,0 +1,46 @@
+package com.example.mody.domain.post.controller;
+
+import com.example.mody.domain.auth.security.CustomUserDetails;
+import com.example.mody.domain.post.dto.request.PostCreateRequest;
+import com.example.mody.domain.post.service.PostCommandService;
+import com.example.mody.global.common.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "POST API", description = "게시글 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class PostController {
+
+    private final PostCommandService postCommandService;
+
+    /**
+     *
+     * @param request
+     * @param customUserDetails 현재는 동작하지 않으므로 SecurityContextHolder에서 직접 memberId를 추출하여 사용함. memberId로 member를 찾는 부분도 서비스 단으로 들어가는게 좋다고 판단되지만, 인증 부분이
+     * @return
+     */
+    @PostMapping
+    @Operation(summary = "게시글 작성 API", description = "인증된 유저의 게시글 작성 API")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "게시글 작성 성공"
+            )
+    })
+    public BaseResponse<Void> registerPost(
+            @Valid @RequestBody PostCreateRequest request, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        postCommandService.createPost(request, customUserDetails.getMember());
+        return BaseResponse.onSuccessCreate(null);
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/mody/domain/post/dto/request/PostCreateRequest.java
@@ -1,0 +1,53 @@
+package com.example.mody.domain.post.dto.request;
+
+import com.example.mody.domain.backupimage.dto.request.BackupFileRequest;
+import com.example.mody.domain.bodytype.entity.BodyType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+
+import static com.example.mody.domain.post.constant.PostConstant.POST_CONTENT_LIMIT;
+
+@Schema(description = "게시글 작성 DTO")
+@Getter
+@NoArgsConstructor
+public class PostCreateRequest {
+
+    @Schema(
+            description = "내용",
+            example = "스트레이트형 착장 예시"
+    )
+    @NotBlank (message = "content 는 필수입니다.")
+    @Length(max = POST_CONTENT_LIMIT, message = "메세지의 최대 길이 {max}를 초과했습니다.")
+    private String content;
+
+
+    @Schema(
+            description = "공개여부",
+            example = "true"
+    )
+    @NotNull(message = "공개여부 입력은 필수입니다.")
+    private Boolean isPublic;
+
+
+    @Schema(
+            description = "파일명, 파일 크기, S3 URL 목록",
+            example = "[{" +
+                    "\"fileName\": \"test.jpg\"," +
+                    "\"fileSize\": 200," +
+                    "\"s3Url\": \"https://mody-s3-bucket.s3.ap-northeast-2.amazonaws.com/filea8500f7a-c902-4f64-b605-7bc6247b4e75\"" +
+                    "}, {" +
+                    "\"fileName\": \"example.png\"," +
+                    "\"fileSize\": 150," +
+                    "\"s3Url\": \"https://mody-s3-bucket.s3.ap-northeast-2.amazonaws.com/fileb8500f7a-c902-4f64-b605-7bc6247b4e76\"" +
+                    "}]"
+    )
+    private List<BackupFileRequest> files;
+}

--- a/src/main/java/com/example/mody/domain/post/entity/Post.java
+++ b/src/main/java/com/example/mody/domain/post/entity/Post.java
@@ -1,0 +1,62 @@
+package com.example.mody.domain.post.entity;
+
+import com.example.mody.domain.bodytype.entity.BodyType;
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.example.mody.domain.post.constant.PostConstant.POST_CONTENT_LIMIT;
+
+@Entity(name = "post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "post")
+@DynamicUpdate
+public class Post extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @OneToMany(mappedBy = "post",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    private List<PostImage> images = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "body_type_id", nullable = false)
+    private BodyType bodyType;
+
+    @Column(length = POST_CONTENT_LIMIT)
+    private String content;
+
+    @Column(nullable = false)
+    private Integer likeCount;
+
+    @Column(nullable = false)
+    private Boolean isPublic;
+
+    @Column(nullable = false)
+    private Integer reportCount;
+
+    public Post(Member member, BodyType bodyType, String content, Boolean isPublic){
+        this.member = member;
+        this.bodyType = bodyType;
+        this.content = content;
+        this.isPublic = isPublic;
+        this.likeCount = 0;
+        this.reportCount = 0;
+        this.images = new ArrayList<>();
+    }
+
+}

--- a/src/main/java/com/example/mody/domain/post/entity/PostImage.java
+++ b/src/main/java/com/example/mody/domain/post/entity/PostImage.java
@@ -1,0 +1,28 @@
+package com.example.mody.domain.post.entity;
+
+import com.example.mody.global.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post_image")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(nullable = false)
+    private String url;
+
+    public PostImage(Post post, String url){
+        this.post = post;
+        this.url = url;
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package com.example.mody.domain.post.repository;
+
+import com.example.mody.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/example/mody/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostCommandService.java
@@ -1,0 +1,9 @@
+package com.example.mody.domain.post.service;
+
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.domain.post.dto.request.PostCreateRequest;
+
+public interface PostCommandService {
+
+    public void createPost(PostCreateRequest postCreateRequest, Member member);
+}

--- a/src/main/java/com/example/mody/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostCommandServiceImpl.java
@@ -1,0 +1,53 @@
+package com.example.mody.domain.post.service;
+
+import com.example.mody.domain.backupimage.service.BackupFileService;
+import com.example.mody.domain.bodytype.entity.BodyType;
+import com.example.mody.domain.bodytype.service.BodyTypeService;
+import com.example.mody.domain.exception.BodyTypeException;
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.domain.post.dto.request.PostCreateRequest;
+import com.example.mody.domain.post.entity.Post;
+import com.example.mody.domain.post.entity.PostImage;
+import com.example.mody.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.example.mody.global.common.exception.code.status.BodyTypeErrorStatus.MEMBER_BODY_TYPE_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class PostCommandServiceImpl implements PostCommandService{
+    private final PostRepository postRepository;
+
+    private final BodyTypeService bodyTypeService;
+    private final BackupFileService backupFileService;
+
+    /**
+     * 게시글 작성 비즈니스 로직. BodyType은 요청 유저의 가장 마지막 BodyType을 적용함. 유저의 BodyType이 존재하지 않을 경우 예외 발생.
+     * @param postCreateRequest
+     * @param member
+     */
+    @Override
+    @Transactional
+    public void createPost(PostCreateRequest postCreateRequest, Member member) {
+        Optional<BodyType> optionalBodyType = bodyTypeService.findLastBodyType(member);
+
+        BodyType bodyType = optionalBodyType.orElseThrow(()-> new BodyTypeException(MEMBER_BODY_TYPE_NOT_FOUND));
+
+        Post post = new Post(member,
+                bodyType,
+                postCreateRequest.getContent(),
+                postCreateRequest.getIsPublic());
+
+        postCreateRequest.getFiles().forEach(file->{
+            PostImage postImage = new PostImage(post, file.getS3Url());
+            post.getImages().add(postImage);
+            backupFileService.saveBackupFile(file); // 백업파일 저장
+        });
+
+        postRepository.save(post);
+    }
+}

--- a/src/main/java/com/example/mody/global/common/base/BaseResponse.java
+++ b/src/main/java/com/example/mody/global/common/base/BaseResponse.java
@@ -25,6 +25,10 @@ public class BaseResponse<T> {
         return new BaseResponse<>("COMMON200", "요청에 성공하였습니다.", result);
     }
 
+    public static <T> BaseResponse<T> onSuccessCreate(T result) {
+        return new BaseResponse<>("COMMON201", "요청에 성공하였습니다.", result);
+    }
+
     public static <T> BaseResponse<T> of(BaseCodeInterface code, T result) {
         return new BaseResponse<>(code.getCode().getCode(), code.getCode().getMessage(), result);
     }

--- a/src/main/java/com/example/mody/global/common/exception/code/status/BodyTypeErrorStatus.java
+++ b/src/main/java/com/example/mody/global/common/exception/code/status/BodyTypeErrorStatus.java
@@ -1,0 +1,30 @@
+package com.example.mody.global.common.exception.code.status;
+
+import com.example.mody.global.common.exception.code.BaseCodeDto;
+import com.example.mody.global.common.exception.code.BaseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BodyTypeErrorStatus implements BaseCodeInterface {
+
+    MEMBER_BODY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_BODY_TYPE404", "체형 분석 결과를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess = false;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCodeDto getCode() {
+        return BaseCodeDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(isSuccess)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mody/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/mody/global/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import com.example.mody.domain.auth.jwt.JwtLoginFilter;
 import com.example.mody.domain.auth.service.AuthCommandService;
 import com.example.mody.domain.auth.service.AuthCommandServiceImpl;
+import com.example.mody.domain.member.service.MemberCommandService;
+import com.example.mody.domain.member.service.MemberQueryService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -41,6 +43,7 @@ public class SecurityConfig {
 	private final ObjectMapper objectMapper;
 	private final AuthenticationConfiguration authenticationConfiguration;
 	private final AuthCommandService authCommandService;
+	private final MemberQueryService memberQueryService;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -99,7 +102,7 @@ public class SecurityConfig {
 
 	@Bean
 	public JwtAuthenticationFilter jwtAuthenticationFilter() {
-		return new JwtAuthenticationFilter(jwtProvider, memberRepository, objectMapper);
+		return new JwtAuthenticationFilter(jwtProvider, memberRepository, objectMapper, memberQueryService);
 	}
 
 	//비밀번호 암호화


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#13 

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 게시글 등록 api 구현
- 엔티티 작성 
  - Post
  - PostImage
  - BackupFile
  - BodyType
  - MemberBodyType 
- SecurityContextHolder에 들어가던 memberId를 Member 객체를 담고 있는 CustomUserDetail로 변경했습니다.  필터 단에서 Member를 찾은 후 member의 id를 인증 객체에 넣어주는 형태였는데 이런 경우 memberId로 다시 member를 찾아야하는 경우가 생길 수 있어서 변경했습니다. 혹시 이 부분에 memberId를 넣어주는 다른 이유가 있었다면 롤백하겠습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

- 위에서 서술한 SecurityContextHolder에 인증 정보를 넣는 필터 부분을 확인해주시면 감사하겠습니다. providerId로 유저를 찾던 부분도 Id로 찾도록 임시로 수정했는데 다음 pr에서 다듬어주시면 좋을 것 같습니다.
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
