### PR TITLE
✨ [FEATURE]#26 게시글 조회 관련 API 작성

### DIFF
--- a/src/main/java/com/example/mody/domain/member/entity/Member.java
+++ b/src/main/java/com/example/mody/domain/member/entity/Member.java
@@ -4,10 +4,11 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.example.mody.domain.bodytype.entity.mapping.MemberBodyType;
+import com.example.mody.domain.post.entity.mapping.MemberPostLike;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
-import com.example.mody.domain.bodytype.entity.mapping.MemberBodyType;
 import com.example.mody.domain.member.enums.Gender;
 import com.example.mody.domain.member.enums.LoginType;
 import com.example.mody.domain.member.enums.Role;
@@ -45,6 +46,12 @@ public class Member extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "member_id")
 	private Long id;
+
+	@OneToMany(mappedBy = "member",
+			cascade = CascadeType.ALL,
+			orphanRemoval = true,
+			fetch = FetchType.LAZY)
+	private List<MemberPostLike> likes = new ArrayList<>();
 
 	private String providerId;  // OAuth2 제공자의 고유 ID
 

--- a/src/main/java/com/example/mody/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/mody/domain/post/controller/PostController.java
@@ -168,4 +168,20 @@ public class PostController {
         PostListResponse postListResponse =  postQueryService.getLikedPosts(customUserDetails.getMember(), size, cursor);
         return BaseResponse.onSuccess(postListResponse);
     }
+
+    @GetMapping("/me")
+    @Operation(summary = "내가 작성한 게시글 목록 조회 API", description = "내가 작성한 게시글에 대한 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 목록 조회 성공"
+            )
+    })
+    public BaseResponse<PostListResponse> getMyPosts(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(name = "cursor", required = false) Long cursor,
+            @RequestParam(name = "size", defaultValue = "15") Integer size) {
+        PostListResponse postListResponse =  postQueryService.getMyPosts(customUserDetails.getMember(), size, cursor);
+        return BaseResponse.onSuccess(postListResponse);
+    }
 }

--- a/src/main/java/com/example/mody/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/mody/domain/post/controller/PostController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.mody.domain.auth.security.CustomUserDetails;
 import com.example.mody.domain.post.dto.request.PostCreateRequest;
 import com.example.mody.domain.post.exception.annotation.ExistsPost;
+import com.example.mody.domain.post.dto.response.PostListResponse;
 import com.example.mody.domain.post.service.PostCommandService;
+import com.example.mody.domain.post.service.PostQueryService;
 import com.example.mody.global.common.base.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +25,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "POST API", description = "게시글 관련 API")
 @RestController
@@ -32,12 +37,29 @@ import lombok.RequiredArgsConstructor;
 @Validated
 public class PostController {
 
-	private final PostCommandService postCommandService;
+    private final PostCommandService postCommandService;
+    private final PostQueryService postQueryService;
+
+    @GetMapping
+    @Operation(summary = "게시글 목록 조회 API", description = "전체 게시글에 대한 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 목록 조회 성공"
+            )
+    })
+    public BaseResponse<PostListResponse> getAllPosts(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(name = "cursor", required = false) Long cursor,
+            @RequestParam(name = "size", defaultValue = "15") Integer size) {
+        PostListResponse postListResponse =  postQueryService.getPosts(customUserDetails.getMember(), size, cursor);
+        return BaseResponse.onSuccess(postListResponse);
+    }
 
 	/**
 	 *
 	 * @param request
-	 * @param customUserDetails 현재는 동작하지 않으므로 SecurityContextHolder에서 직접 memberId를 추출하여 사용함. memberId로 member를 찾는 부분도 서비스 단으로 들어가는게 좋다고 판단되지만, 인증 부분이
+	 * @param customUserDetails
 	 * @return
 	 */
 	@PostMapping

--- a/src/main/java/com/example/mody/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/mody/domain/post/controller/PostController.java
@@ -152,4 +152,20 @@ public class PostController {
 		postCommandService.togglePostLike(myId, postId);
 		return BaseResponse.onSuccess(null);
 	}
+
+    @GetMapping("/liked")
+    @Operation(summary = "좋아요 누른 목록 조회 API", description = "좋아요 누른 게시글에 대한 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 목록 조회 성공"
+            )
+    })
+    public BaseResponse<PostListResponse> getLikedPosts(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(name = "cursor", required = false) Long cursor,
+            @RequestParam(name = "size", defaultValue = "15") Integer size) {
+        PostListResponse postListResponse =  postQueryService.getLikedPosts(customUserDetails.getMember(), size, cursor);
+        return BaseResponse.onSuccess(postListResponse);
+    }
 }

--- a/src/main/java/com/example/mody/domain/post/dto/response/PostImageResponse.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/PostImageResponse.java
@@ -1,0 +1,15 @@
+package com.example.mody.domain.post.dto.response;
+
+import com.example.mody.domain.post.entity.PostImage;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostImageResponse {
+    private String s3Url;
+    public static PostImageResponse from(PostImage postImage){
+        return new PostImageResponse(postImage.getUrl());
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/dto/response/PostListResponse.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/PostListResponse.java
@@ -1,0 +1,19 @@
+package com.example.mody.domain.post.dto.response;
+
+import com.example.mody.global.dto.response.CursorPagination;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostListResponse {
+    private List<PostResponse> postResponses;
+    private CursorPagination cursorPagination;
+
+    public static PostListResponse from(Boolean hasNext, List<PostResponse> postResponses){
+        return new PostListResponse(postResponses, new CursorPagination(hasNext, postResponses.getLast().getPostId()));
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/dto/response/PostListResponse.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/PostListResponse.java
@@ -17,4 +17,9 @@ public class PostListResponse {
         Long cursor = hasNext ? postResponses.getLast().getPostId() : null;
         return new PostListResponse(postResponses, new CursorPagination(hasNext, cursor));
     }
+
+    public static PostListResponse from(Boolean hasNext, List<PostResponse> postResponses, Long cursor){
+        Long newCursor = hasNext ? cursor : null;
+        return new PostListResponse(postResponses, new CursorPagination(hasNext, newCursor));
+    }
 }

--- a/src/main/java/com/example/mody/domain/post/dto/response/PostListResponse.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/PostListResponse.java
@@ -14,6 +14,7 @@ public class PostListResponse {
     private CursorPagination cursorPagination;
 
     public static PostListResponse from(Boolean hasNext, List<PostResponse> postResponses){
-        return new PostListResponse(postResponses, new CursorPagination(hasNext, postResponses.getLast().getPostId()));
+        Long cursor = hasNext ? postResponses.getLast().getPostId() : null;
+        return new PostListResponse(postResponses, new CursorPagination(hasNext, cursor));
     }
 }

--- a/src/main/java/com/example/mody/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/PostResponse.java
@@ -1,0 +1,43 @@
+package com.example.mody.domain.post.dto.response;
+
+import com.example.mody.domain.bodytype.entity.BodyType;
+import com.example.mody.domain.post.entity.PostImage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PostResponse {
+
+    private Long postId;
+    private String nickName;
+    private String content;
+    private Boolean isPublic;
+    private Integer likeCount;
+    private Boolean isLiked;
+    private String bodyType;
+    private List<PostImageResponse> files;
+
+    public PostResponse(Long postId,
+                        String nickName ,
+                        String content,
+                        Boolean isPublic,
+                        Integer likeCount,
+                        Boolean isLiked,
+                        String bodyType,
+                        List<PostImage> files) {
+        this.postId = postId;
+        this.nickName = nickName;
+        this.content = content;
+        this.isPublic = isPublic;
+        this.likeCount = likeCount;
+        this.isLiked = isLiked;
+        this.bodyType = bodyType;
+        this.files = files.stream()
+                .map(PostImageResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/PostResponse.java
@@ -13,7 +13,8 @@ import java.util.List;
 public class PostResponse {
 
     private Long postId;
-    private String nickName;
+    private Long writerId;
+    private String writerNickName;
     private String content;
     private Boolean isPublic;
     private Integer likeCount;
@@ -22,7 +23,8 @@ public class PostResponse {
     private List<PostImageResponse> files;
 
     public PostResponse(Long postId,
-                        String nickName ,
+                        Long writerId,
+                        String nickName,
                         String content,
                         Boolean isPublic,
                         Integer likeCount,
@@ -30,7 +32,8 @@ public class PostResponse {
                         String bodyType,
                         List<PostImage> files) {
         this.postId = postId;
-        this.nickName = nickName;
+        this.writerId = writerId;
+        this.writerNickName = nickName;
         this.content = content;
         this.isPublic = isPublic;
         this.likeCount = likeCount;

--- a/src/main/java/com/example/mody/domain/post/dto/response/recode/LikedPostsResponse.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/recode/LikedPostsResponse.java
@@ -1,0 +1,8 @@
+package com.example.mody.domain.post.dto.response.recode;
+
+import com.example.mody.domain.post.dto.response.PostResponse;
+
+import java.util.List;
+
+public record LikedPostsResponse(Boolean hasNext, List<PostResponse> postResponses) {
+}

--- a/src/main/java/com/example/mody/domain/post/entity/PostImage.java
+++ b/src/main/java/com/example/mody/domain/post/entity/PostImage.java
@@ -3,11 +3,13 @@ package com.example.mody.domain.post.entity;
 import com.example.mody.global.common.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "post_image")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class PostImage extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/mody/domain/post/repository/MemberPostLikeRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/MemberPostLikeRepository.java
@@ -11,5 +11,5 @@ import com.example.mody.domain.post.entity.mapping.MemberPostLike;
 public interface MemberPostLikeRepository extends JpaRepository<MemberPostLike, Long> {
 
 	Optional<MemberPostLike> findByPostAndMember(Post post, Member member);
-	
+    Optional<MemberPostLike> findByMemberAndPostId(Member member, Long postId);
 }

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
@@ -1,0 +1,13 @@
+package com.example.mody.domain.post.repository;
+
+import com.example.mody.domain.bodytype.entity.BodyType;
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.domain.post.dto.response.PostListResponse;
+import jakarta.persistence.EntityManager;
+
+import java.util.Optional;
+
+public interface PostCustomRepository {
+
+    public PostListResponse getPostList(Long cursor, Integer size, Member member, Optional<BodyType> bodyType);
+}

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
@@ -3,13 +3,15 @@ package com.example.mody.domain.post.repository;
 import com.example.mody.domain.bodytype.entity.BodyType;
 import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.dto.response.recode.LikedPostsResponse;
+import com.example.mody.domain.post.entity.Post;
 import jakarta.persistence.EntityManager;
 
 import java.util.Optional;
 
 public interface PostCustomRepository {
 
-    public PostListResponse getPostList(Long cursor, Integer size, Member member, Optional<BodyType> bodyType);
-    public PostListResponse getLikedPosts(Long cursor, Integer size, Member member);
+    public PostListResponse getPostList(Optional<Post> cursorPost, Integer size, Member member, Optional<BodyType> bodyType);
+    public LikedPostsResponse getLikedPosts(Long cursor, Integer size, Member member);
     public PostListResponse getMyPosts(Long cursor, Integer size, Member member);
 }

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface PostCustomRepository {
 
     public PostListResponse getPostList(Long cursor, Integer size, Member member, Optional<BodyType> bodyType);
+    public PostListResponse getLikedPosts(Long cursor, Integer size, Member member);
 }

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
@@ -11,4 +11,5 @@ public interface PostCustomRepository {
 
     public PostListResponse getPostList(Long cursor, Integer size, Member member, Optional<BodyType> bodyType);
     public PostListResponse getLikedPosts(Long cursor, Integer size, Member member);
+    public PostListResponse getMyPosts(Long cursor, Integer size, Member member);
 }

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,121 @@
+package com.example.mody.domain.post.repository;
+
+import com.example.mody.domain.bodytype.entity.BodyType;
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.domain.member.entity.QMember;
+import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.dto.response.PostResponse;
+import com.example.mody.domain.post.entity.QPost;
+import com.example.mody.domain.post.entity.QPostImage;
+import com.example.mody.domain.post.entity.mapping.QMemberPostLike;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+import java.util.function.BiFunction;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class PostCustomRepositoryImpl implements PostCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QPost qPost = QPost.post;
+    private final QMember qMember = QMember.member;
+    private final QMemberPostLike qMemberPostLike = QMemberPostLike.memberPostLike;
+    private final QPostImage qPostImage = QPostImage.postImage;
+
+
+    /**
+     * 조회할 post 목록을 조회하는 쿼리, 해당 목록의 데이터들을 가져오는 쿼리가 날라감.
+     * @param cursor
+     * @param size
+     * @param member
+     * @param bodyType
+     * @return
+     */
+    @Override
+    public PostListResponse getPostList(Long cursor, Integer size, Member member, Optional<BodyType> bodyType) {
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        NumberExpression<Integer> caseExpression = bodyTypeOrderCase(bodyType);
+
+        predicate.and(qPost.isPublic.eq(true)); // 공개여부 == true
+
+        if(cursor != null){
+            predicate.and(qPost.id.lt(cursor));
+        }
+
+        BooleanExpression isLiked = Expressions.asBoolean(false);
+        if (member != null){
+            isLiked = isLikedResult(member);
+        }
+
+        List<Long> postIds = jpaQueryFactory
+                .select(qPost.id)
+                .from(qPost)
+                .where(predicate)
+                .orderBy(caseExpression.asc(), qPost.createdAt.desc())
+                .limit(size+1) //하나 더 가져와서 다음 요소가 존재하는지 확인
+                .fetch();
+
+        Map<Long, PostResponse> postResponseMap = jpaQueryFactory
+                .from(qPost)
+                .leftJoin(qPost.member, qMember)
+                .leftJoin(qPost.images, qPostImage)
+                .where(qPost.id.in(postIds))
+                .orderBy(caseExpression.asc(), qPost.createdAt.desc())
+                .transform(GroupBy.groupBy(qPost.id).as(
+                        Projections.constructor(PostResponse.class,
+                                qPost.id,
+                                qMember.nickname,
+                                qPost.content,
+                                qPost.isPublic,
+                                qPost.likeCount,
+                                isLiked,
+                                qPost.bodyType.name,
+                                GroupBy.list(qPostImage)
+                        )));
+
+        List<PostResponse> postResponses = new ArrayList<>(postResponseMap.values());
+
+        return PostListResponse.from(hasNext.apply(postResponses, size),
+                postResponses.subList(0, Math.min(size, postResponses.size())));
+    }
+
+    private BiFunction<List<PostResponse> , Integer, Boolean> hasNext = (list, size) -> list.size() > size;
+
+
+    /**
+     * // 정렬 기준. 특정 바디 타입이 요구되지 않으면 전부 1
+     * @param bodyType
+     * @return
+     */
+    private NumberExpression<Integer> bodyTypeOrderCase(Optional<BodyType> bodyType){
+        if(bodyType.isPresent()){
+            return new CaseBuilder()
+                    .when(qPost.bodyType.eq(bodyType.get())).then(0)
+                    .otherwise(1);
+        }
+        return  Expressions.asNumber(1);
+    }
+
+    private BooleanExpression isLikedResult(Member member){
+        return JPAExpressions.selectFrom(qMemberPostLike)
+                .where(qMemberPostLike.post.eq(qPost)
+                        .and(qMemberPostLike.member.eq(member)))
+                .exists();
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
@@ -75,6 +75,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                 .from(qPost)
                 .leftJoin(qPost.member, qMember)
                 .leftJoin(qPost.images, qPostImage)
+                .leftJoin(qMemberPostLike).on(qMemberPostLike.post.eq(qPost))
                 .where(qPost.id.in(postIds))
                 .orderBy(caseExpression.asc(), qPost.createdAt.desc())
                 .transform(GroupBy.groupBy(qPost.id).as(
@@ -205,9 +206,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
     }
 
     private BooleanExpression isLikedResult(Member member){
-        return JPAExpressions.selectFrom(qMemberPostLike)
-                .where(qMemberPostLike.post.eq(qPost)
-                        .and(qMemberPostLike.member.eq(member)))
+        return JPAExpressions
+                .selectFrom(qMemberPostLike)
+                .where(qMemberPostLike.member.eq(member).and(qMemberPostLike.post.eq(qPost)))
                 .exists();
     }
 }

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
@@ -85,6 +85,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                 .transform(GroupBy.groupBy(qPost.id).as(
                         Projections.constructor(PostResponse.class,
                                 qPost.id,
+                                qMember.id,
                                 qMember.nickname,
                                 qPost.content,
                                 qPost.isPublic,
@@ -134,6 +135,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                 .transform(GroupBy.groupBy(qPost.id).as(
                         Projections.constructor(PostResponse.class,
                                 qPost.id,
+                                qMember.id,
                                 qMember.nickname,
                                 qPost.content,
                                 qPost.isPublic,
@@ -180,6 +182,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                 .transform(GroupBy.groupBy(qPost.id).as(
                         Projections.constructor(PostResponse.class,
                                 qPost.id,
+                                qMember.id,
                                 qMember.nickname,
                                 qPost.content,
                                 qPost.isPublic,

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
@@ -5,16 +5,17 @@ import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.member.entity.QMember;
 import com.example.mody.domain.post.dto.response.PostListResponse;
 import com.example.mody.domain.post.dto.response.PostResponse;
+import com.example.mody.domain.post.dto.response.recode.LikedPostsResponse;
+import com.example.mody.domain.post.entity.Post;
 import com.example.mody.domain.post.entity.QPost;
 import com.example.mody.domain.post.entity.QPostImage;
 import com.example.mody.domain.post.entity.mapping.QMemberPostLike;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.*;
+import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.BiFunction;
 
@@ -40,22 +42,24 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
 
     /**
      * 게시글 전체 조회. 조회할 post 목록을 조회하는 쿼리, 해당 목록의 데이터들을 가져오는 쿼리, 각 게시글 별 좋아요 여부 확인 쿼리가 날라감.
-     * @param cursor
+     * @param cursorPost
      * @param size
      * @param member
      * @param bodyType
      * @return
      */
     @Override
-    public PostListResponse getPostList(Long cursor, Integer size, Member member, Optional<BodyType> bodyType) {
+    public PostListResponse getPostList(Optional<Post> cursorPost, Integer size, Member member, Optional<BodyType> bodyType) {
         BooleanBuilder predicate = new BooleanBuilder();
 
-        NumberExpression<Integer> caseExpression = bodyTypeOrderCase(bodyType);
+        NumberExpression<Integer> caseExpression = orderedBodyType(bodyType);
 
         predicate.and(qPost.isPublic.eq(true)); // 공개여부 == true
 
-        if(cursor != null){
-            predicate.and(qPost.id.lt(cursor));
+        if(cursorPost.isPresent()){
+            String customCursor = createCustomCursor(cursorPost.get(), bodyType);
+            log.info(customCursor);
+            predicate.and(applyCustomCursor(customCursor, bodyType));
         }
 
         BooleanExpression isLiked = Expressions.asBoolean(false);
@@ -98,16 +102,16 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
 
     /**
      * 좋아요 누른 게시글 목록 조회
-     * @param cursor
+     * @param cursor 좋아요의 id
      * @param size
      * @param member
      * @return
      */
-    public PostListResponse getLikedPosts(Long cursor, Integer size, Member member) {
+    public LikedPostsResponse getLikedPosts(Long cursor, Integer size, Member member) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         if(cursor != null){
-            predicate.and(qPost.id.lt(cursor));
+            predicate.and(qMemberPostLike.id.lt(cursor));
         }
 
         predicate.and(qMemberPostLike.member.eq(member));
@@ -141,7 +145,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
 
         List<PostResponse> postResponses = new ArrayList<>(postResponseMap.values());
 
-        return PostListResponse.from(hasNext.apply(postResponses, size),
+        return new LikedPostsResponse(
+                hasNext.apply(postResponses, size),
                 postResponses.subList(0, Math.min(size, postResponses.size())));
     }
 
@@ -149,9 +154,13 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
     public PostListResponse getMyPosts(Long cursor, Integer size, Member member) {
         BooleanBuilder predicate = new BooleanBuilder();
 
+        predicate.and(qPost.member.eq(member));
+
         if(cursor != null){
             predicate.and(qPost.id.lt(cursor));
         }
+
+        log.info(predicate.toString());
 
         List<Long> postIds = jpaQueryFactory
                 .select(qPost.id)
@@ -175,10 +184,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                                 qPost.content,
                                 qPost.isPublic,
                                 qPost.likeCount,
-                                JPAExpressions
-                                        .selectFrom(qMemberPostLike)
-                                        .where(qMemberPostLike.member.eq(member).and(qMemberPostLike.post.eq(qPost)))
-                                        .exists(),
+                                isLikedResult(member),
                                 qPost.bodyType.name,
                                 GroupBy.list(qPostImage)
                         )));
@@ -196,7 +202,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
      * @param bodyType
      * @return
      */
-    private NumberExpression<Integer> bodyTypeOrderCase(Optional<BodyType> bodyType){
+    private NumberExpression<Integer> orderedBodyType(Optional<BodyType> bodyType){
         if(bodyType.isPresent()){
             return new CaseBuilder()
                     .when(qPost.bodyType.eq(bodyType.get())).then(0)
@@ -205,10 +211,66 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
         return  Expressions.asNumber(1);
     }
 
+    private StringExpression isMatchedBodyType(Optional<BodyType> bodyType){
+        if(bodyType.isPresent()){
+            return new CaseBuilder()
+                    .when(qPost.bodyType.eq(bodyType.get())).then("1")
+                    .otherwise("0");
+        }
+        return  Expressions.asString("0");
+    }
+
     private BooleanExpression isLikedResult(Member member){
         return JPAExpressions
                 .selectFrom(qMemberPostLike)
                 .where(qMemberPostLike.member.eq(member).and(qMemberPostLike.post.eq(qPost)))
                 .exists();
     }
+
+    private String createCustomCursor(Post cursor, Optional<BodyType> bodyType){
+        if (cursor == null || bodyType == null) {
+            return null;
+        }
+
+        String isMatchedBodyType = "0";
+        if(bodyType.isPresent()){
+            if(cursor.getBodyType().getId().equals(bodyType.get().getId())){
+                isMatchedBodyType = "1";
+            }
+        }
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+        return isMatchedBodyType + String.format("%19s", formatter.format(cursor.getCreatedAt())).replaceAll(" ","0");
+    }
+
+    /**
+     * createdAt을 'YYYYMMDDHHmmss' 로 변환
+     * @return
+     */
+    private StringTemplate mySqlDateFormat(){
+        return Expressions.stringTemplate(
+                "CAST(DATE_FORMAT({0}, {1}) AS STRING)",
+                qPost.createdAt,
+                ConstantImpl.create("%Y%m%d%H%i%s")
+        );
+    }
+
+    private StringExpression formatCreatedAt(StringTemplate stringTemplate){
+        return StringExpressions.lpad(stringTemplate, 19, '0');
+    }
+
+    private BooleanExpression applyCustomCursor(String customCursor, Optional<BodyType> bodyType) {
+        if (customCursor == null) { // 커서가 없으면 조건 없음
+            return null;
+        }
+
+        // bodyType 순서 계산
+        StringExpression isMatchedBodyType = isMatchedBodyType(bodyType); // bodyType 일치 여부
+        StringTemplate postCreatedAtTemplate = mySqlDateFormat(); //DATE_FORMAT으로 날짜 형태 변경
+        StringExpression formattedCreatedAt = formatCreatedAt(postCreatedAtTemplate); // 날짜 형태 변경을 포맷
+
+        return isMatchedBodyType.concat(formattedCreatedAt)
+                .lt(customCursor);
+    }
+
 }

--- a/src/main/java/com/example/mody/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryService.java
@@ -4,8 +4,7 @@ import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.post.dto.response.PostListResponse;
 
 public interface PostQueryService {
-    public PostListResponse getPosts(Member member, Integer size, Long lastPostId);
+    public PostListResponse getPosts(Member member, Integer size, Long cursor);
 
-    public PostListResponse getMyPosts(Member member, Integer size, Long lastPostId);
-
+    public PostListResponse getLikedPosts(Member member, Integer size, Long cursor);
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryService.java
@@ -5,6 +5,6 @@ import com.example.mody.domain.post.dto.response.PostListResponse;
 
 public interface PostQueryService {
     public PostListResponse getPosts(Member member, Integer size, Long cursor);
-
     public PostListResponse getLikedPosts(Member member, Integer size, Long cursor);
+    public PostListResponse getMyPosts(Member member, Integer size, Long cursor);
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryService.java
@@ -1,0 +1,11 @@
+package com.example.mody.domain.post.service;
+
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.domain.post.dto.response.PostListResponse;
+
+public interface PostQueryService {
+    public PostListResponse getPosts(Member member, Integer size, Long lastPostId);
+
+    public PostListResponse getMyPosts(Member member, Integer size, Long lastPostId);
+
+}

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
@@ -17,6 +17,7 @@ import com.example.mody.global.common.exception.code.status.MemberPostLikeErrorS
 import com.example.mody.global.common.exception.code.status.PostErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -28,6 +29,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     private final MemberPostLikeRepository memberPostLikeRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public PostListResponse getPosts(Member member, Integer size, Long cursor) {
 
         if(size<=0){
@@ -45,6 +47,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PostListResponse getLikedPosts(Member member, Integer size, Long cursor) {
         if(size<=0){
             throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
@@ -58,6 +61,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public PostListResponse getMyPosts(Member member, Integer size, Long cursor) {
         if(size<=0){
             throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
@@ -1,0 +1,42 @@
+package com.example.mody.domain.post.service;
+
+import com.example.mody.domain.bodytype.entity.BodyType;
+import com.example.mody.domain.bodytype.service.BodyTypeService;
+import com.example.mody.domain.member.entity.Member;
+import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.repository.PostRepository;
+import com.example.mody.global.common.exception.RestApiException;
+import com.example.mody.global.common.exception.code.status.GlobalErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PostQueryServiceImpl implements PostQueryService {
+    private final PostRepository postRepository;
+
+    private final BodyTypeService bodyTypeService;
+
+
+    @Override
+    public PostListResponse getPosts(Member member, Integer size, Long cursor) {
+
+        if(size<=0){
+            throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
+        }
+
+        if(member != null){
+            Optional<BodyType> bodyTypeOptional = bodyTypeService.findLastBodyType(member);
+            return postRepository.getPostList(cursor, size, member, bodyTypeOptional);
+        }
+
+        return postRepository.getPostList(cursor, size, member, Optional.empty());
+    }
+
+    @Override
+    public PostListResponse getMyPosts(Member member, Integer size, Long lastPostId) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
@@ -42,4 +42,12 @@ public class PostQueryServiceImpl implements PostQueryService {
         }
         return postRepository.getLikedPosts(cursor, size, member);
     }
+
+    @Override
+    public PostListResponse getMyPosts(Member member, Integer size, Long cursor) {
+        if(size<=0){
+            throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
+        }
+        return postRepository.getMyPosts(cursor, size, member);
+    }
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
@@ -36,7 +36,10 @@ public class PostQueryServiceImpl implements PostQueryService {
     }
 
     @Override
-    public PostListResponse getMyPosts(Member member, Integer size, Long lastPostId) {
-        return null;
+    public PostListResponse getLikedPosts(Member member, Integer size, Long cursor) {
+        if(size<=0){
+            throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
+        }
+        return postRepository.getLikedPosts(cursor, size, member);
     }
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
@@ -2,11 +2,19 @@ package com.example.mody.domain.post.service;
 
 import com.example.mody.domain.bodytype.entity.BodyType;
 import com.example.mody.domain.bodytype.service.BodyTypeService;
+import com.example.mody.domain.exception.PostException;
 import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.dto.response.PostResponse;
+import com.example.mody.domain.post.dto.response.recode.LikedPostsResponse;
+import com.example.mody.domain.post.entity.Post;
+import com.example.mody.domain.post.entity.mapping.MemberPostLike;
+import com.example.mody.domain.post.repository.MemberPostLikeRepository;
 import com.example.mody.domain.post.repository.PostRepository;
 import com.example.mody.global.common.exception.RestApiException;
 import com.example.mody.global.common.exception.code.status.GlobalErrorStatus;
+import com.example.mody.global.common.exception.code.status.MemberPostLikeErrorStatus;
+import com.example.mody.global.common.exception.code.status.PostErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,10 +23,9 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class PostQueryServiceImpl implements PostQueryService {
-    private final PostRepository postRepository;
-
     private final BodyTypeService bodyTypeService;
-
+    private final PostRepository postRepository;
+    private final MemberPostLikeRepository memberPostLikeRepository;
 
     @Override
     public PostListResponse getPosts(Member member, Integer size, Long cursor) {
@@ -27,12 +34,14 @@ public class PostQueryServiceImpl implements PostQueryService {
             throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
         }
 
+        Optional<Post> cursorPost = getCursorPost(cursor);
+
         if(member != null){
             Optional<BodyType> bodyTypeOptional = bodyTypeService.findLastBodyType(member);
-            return postRepository.getPostList(cursor, size, member, bodyTypeOptional);
+            return postRepository.getPostList(cursorPost, size, member, bodyTypeOptional);
         }
 
-        return postRepository.getPostList(cursor, size, member, Optional.empty());
+        return postRepository.getPostList(cursorPost, size, member, Optional.empty());
     }
 
     @Override
@@ -40,7 +49,12 @@ public class PostQueryServiceImpl implements PostQueryService {
         if(size<=0){
             throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
         }
-        return postRepository.getLikedPosts(cursor, size, member);
+        LikedPostsResponse likedPostsResponse = postRepository.getLikedPosts(cursor, size, member);
+
+        PostResponse postResponse = likedPostsResponse.postResponses().getLast();
+        MemberPostLike memberPostLike = findByMemberAndPostId(member, postResponse.getPostId());
+
+        return PostListResponse.from(likedPostsResponse.hasNext(), likedPostsResponse.postResponses(), memberPostLike.getId());
     }
 
     @Override
@@ -50,4 +64,19 @@ public class PostQueryServiceImpl implements PostQueryService {
         }
         return postRepository.getMyPosts(cursor, size, member);
     }
+
+    public Optional getCursorPost(Long cursor){
+        return cursor != null ? Optional.ofNullable(findById(cursor)) : Optional.empty();
+    }
+
+    public Post findById(Long id){
+        return postRepository.findById(id).orElseThrow(()->
+                new PostException(PostErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    public MemberPostLike findByMemberAndPostId(Member member, Long postId){
+        return memberPostLikeRepository.findByMemberAndPostId(member, postId).orElseThrow(()
+                -> new PostException(MemberPostLikeErrorStatus.LIKE_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
@@ -71,7 +71,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     public Post findById(Long id){
         return postRepository.findById(id).orElseThrow(()->
-                new PostException(PostErrorStatus.MEMBER_NOT_FOUND));
+                new PostException(PostErrorStatus.POST_NOT_FOUND));
     }
 
     public MemberPostLike findByMemberAndPostId(Member member, Long postId){

--- a/src/main/java/com/example/mody/global/common/exception/code/status/GlobalErrorStatus.java
+++ b/src/main/java/com/example/mody/global/common/exception/code/status/GlobalErrorStatus.java
@@ -27,6 +27,9 @@ public enum GlobalErrorStatus implements BaseCodeInterface {
 
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "예외처리 테스트입니다."),
+
+    //페이지 관련 오류
+    NEGATIVE_PAGE_SIZE_REQUEST(HttpStatus.BAD_REQUEST, "PAGE4001", "잘못된 페이지 사이즈 요청입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/mody/global/common/exception/code/status/MemberPostLikeErrorStatus.java
+++ b/src/main/java/com/example/mody/global/common/exception/code/status/MemberPostLikeErrorStatus.java
@@ -1,0 +1,30 @@
+package com.example.mody.global.common.exception.code.status;
+
+import ch.qos.logback.core.spi.ErrorCodes;
+import com.example.mody.global.common.exception.code.BaseCodeDto;
+import com.example.mody.global.common.exception.code.BaseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberPostLikeErrorStatus implements BaseCodeInterface {
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_POST_LIEK404", "해당 좋아요를 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess = false;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCodeDto getCode() {
+        return BaseCodeDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(isSuccess)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mody/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/example/mody/global/config/QueryDSLConfig.java
@@ -1,5 +1,6 @@
 package com.example.mody.global.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,6 @@ public class QueryDSLConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/src/main/java/com/example/mody/global/dto/response/CursorPagination.java
+++ b/src/main/java/com/example/mody/global/dto/response/CursorPagination.java
@@ -1,0 +1,11 @@
+package com.example.mody.global.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CursorPagination {
+    private Boolean hasNext;
+    private Long cursor;
+}


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
Closes #26 
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 전체 게시글 목록 조회 
- 좋아요 누른 게시글 목록 조회
- 내가 작성한 게시글 목록 조회 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 페이지 네이션을 커서 기반으로 사용함.
- 전체 목록 조회 시 커서는 postId. 정렬 기준은 아래와 같음
  - bodyType이 일치하는가
  - 생성일자(createdAt)
  - 전체 목록 조회의 내부로직에선 커서인 postId의 post를 사용하여 bodyType이 일치하는지 여부(length: 1)와 createdAt(length: 19. 빈칸을 좌측부터 0으로 채움)을 합쳐서 20자의 커스텀 커서를 생성하고 이를 기준으로 비교하여 커서 페이징을 수행.
- 좋아요 게시글 목록 조회 
  - 정렬 기준: 좋아요 누른 순서
  - 커서:  좋아요 id
- 내가 작성한 게시글 목록 조회 
  - 정렬 기준: 생성일자(createdAt)
  - 커서: postId
- 목록 조회 결과의 페이지네이션에는 아래 항목들이 존재
  - hasNext: 다음 페이지 존재 여부
  - cursor: 커서  
- 목록 조회의 URI의 QueryParameter 에는 아래 항목들이 존재. 두 값은 모두 필수 입력값이 아님.
  - size: default == 15
  - cursor: 이전 페이지에서 제공되었던 cursor값. 최초 조회 시에는 사용하지 않음

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
