### PR TITLE
Feature/#59 presigned url 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	// AWS 서비스 의존성 추가
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 
 	//Webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/com/example/mody/domain/bodytype/controller/BodyTypeController.java
+++ b/src/main/java/com/example/mody/domain/bodytype/controller/BodyTypeController.java
@@ -1,7 +1,8 @@
 package com.example.mody.domain.bodytype.controller;
 
 import com.example.mody.domain.auth.security.CustomUserDetails;
-import com.example.mody.domain.bodytype.dto.BodyTypeAnalysisResponse;
+import com.example.mody.domain.bodytype.dto.request.BodyTypeAnalysisRequest;
+import com.example.mody.domain.bodytype.dto.response.BodyTypeAnalysisResponse;
 import com.example.mody.domain.bodytype.service.memberbodytype.MemberBodyTypeCommandService;
 import com.example.mody.domain.bodytype.service.memberbodytype.MemberBodyTypeQueryService;
 import com.example.mody.global.common.base.BaseResponse;
@@ -23,19 +24,19 @@ public class BodyTypeController {
     private final MemberBodyTypeQueryService memberBodyTypeQueryService;
 
     @PostMapping("/result")
-    @Operation(summary = "체형 분석 API", description = "OpenAi를 사용해서 사용자의 체형을 분석하는 API입니다. Request Body에는 질문에 맞는 답변 목록을 String으로 보내주세요.")
+    @Operation(summary = "체형 분석 API", description = "OpenAi를 사용해서 사용자의 체형을 분석하는 API입니다. Request Body에는 질문에 맞는 답변 목록을 보내주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
     })
     public BaseResponse<BodyTypeAnalysisResponse> analyzeBodyType(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @Valid @RequestBody String answers
+            @Valid @RequestBody BodyTypeAnalysisRequest request
     ) {
-        return BaseResponse.onSuccess(memberBodyTypeCommandService.analyzeBodyType(customUserDetails.getMember(), answers));
+        return BaseResponse.onSuccess(memberBodyTypeCommandService.analyzeBodyType(customUserDetails.getMember(), request.getAnswer()));
     }
 
     @GetMapping()
-    @Operation(summary = "체형 질문 문항 조회 API - 프론트와 협의 필요",
+    @Operation(summary = "체형 질문 문항 조회 API - 프론트와 협의 필요(API 연동 안 해도 됨)",
             description = "체형 분석을 하기 위해 질문 문항을 받아 오는 API입니다. 이 부분은 서버에서 바로 프롬프트로 넣는 방법도 있기 때문에 프론트와 협의 후 진행하겠습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")

--- a/src/main/java/com/example/mody/domain/bodytype/dto/request/BodyTypeAnalysisRequest.java
+++ b/src/main/java/com/example/mody/domain/bodytype/dto/request/BodyTypeAnalysisRequest.java
@@ -1,0 +1,29 @@
+package com.example.mody.domain.bodytype.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 체형 분석 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class BodyTypeAnalysisRequest {
+    @Schema(description = "체형 분석 질문에 대한 답변", example = "목 두께가 얇고 상대적으로 긴 편이다. "
+            + "쇄골이 굵고 단단하며 뼈와 힘줄이 돋보인다. "
+            + "보송보송하고 관절과 힘줄이 부각된다. "
+            + "다리 길이가 상대적으로 긴 편이다. "
+            + "허리가 굴곡이 없는 편이다. "
+            + "어깨의 뼈가 크고 넓은 편이다. "
+            + "엉덩이가 입체적이며 탄탄하다. "
+            + "어깨선 및 쇄골뼈가 부각되어 있다. "
+            + "탄탄하고 근육이 붙어있다. "
+            + "팔, 가슴, 배 등 상체 위주로 살이 찐다. "
+            + "보통이다.")
+    private String answer;
+}

--- a/src/main/java/com/example/mody/domain/bodytype/dto/response/BodyTypeAnalysisResponse.java
+++ b/src/main/java/com/example/mody/domain/bodytype/dto/response/BodyTypeAnalysisResponse.java
@@ -1,4 +1,4 @@
-package com.example.mody.domain.bodytype.dto;
+package com.example.mody.domain.bodytype.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeCommandService.java
+++ b/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeCommandService.java
@@ -1,6 +1,6 @@
 package com.example.mody.domain.bodytype.service.memberbodytype;
 
-import com.example.mody.domain.bodytype.dto.BodyTypeAnalysisResponse;
+import com.example.mody.domain.bodytype.dto.response.BodyTypeAnalysisResponse;
 import com.example.mody.domain.member.entity.Member;
 
 public interface MemberBodyTypeCommandService {

--- a/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeCommandServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeCommandServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.mody.domain.bodytype.service.memberbodytype;
 
-import com.example.mody.domain.bodytype.dto.BodyTypeAnalysisResponse;
+import com.example.mody.domain.bodytype.dto.response.BodyTypeAnalysisResponse;
 import com.example.mody.domain.bodytype.entity.BodyType;
 import com.example.mody.domain.bodytype.entity.mapping.MemberBodyType;
 import com.example.mody.domain.bodytype.repository.MemberBodyTypeRepository;

--- a/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeQueryService.java
+++ b/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeQueryService.java
@@ -1,6 +1,6 @@
 package com.example.mody.domain.bodytype.service.memberbodytype;
 
-import com.example.mody.domain.bodytype.dto.BodyTypeAnalysisResponse;
+import com.example.mody.domain.bodytype.dto.response.BodyTypeAnalysisResponse;
 import com.example.mody.domain.member.entity.Member;
 
 public interface MemberBodyTypeQueryService {

--- a/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeQueryServiceImpl.java
@@ -1,11 +1,10 @@
 package com.example.mody.domain.bodytype.service.memberbodytype;
 
-import com.example.mody.domain.bodytype.dto.BodyTypeAnalysisResponse;
+import com.example.mody.domain.bodytype.dto.response.BodyTypeAnalysisResponse;
 import com.example.mody.domain.bodytype.entity.mapping.MemberBodyType;
 import com.example.mody.domain.bodytype.repository.MemberBodyTypeRepository;
 import com.example.mody.domain.exception.BodyTypeException;
 import com.example.mody.domain.member.entity.Member;
-import com.example.mody.global.common.base.BaseResponse;
 import com.example.mody.global.common.exception.code.status.BodyTypeErrorStatus;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/example/mody/domain/chatgpt/service/ChatGptService.java
+++ b/src/main/java/com/example/mody/domain/chatgpt/service/ChatGptService.java
@@ -1,8 +1,6 @@
 package com.example.mody.domain.chatgpt.service;
 
-import com.example.mody.domain.bodytype.dto.BodyTypeAnalysisResponse;
-import com.example.mody.domain.bodytype.entity.mapping.MemberBodyType;
-import com.example.mody.domain.member.entity.Member;
+import com.example.mody.domain.bodytype.dto.response.BodyTypeAnalysisResponse;
 import com.example.mody.domain.member.enums.Gender;
 import com.example.mody.domain.style.dto.request.StyleRecommendRequest;
 import com.example.mody.domain.style.dto.response.StyleRecommendResponse;

--- a/src/main/java/com/example/mody/domain/image/controller/S3Controller.java
+++ b/src/main/java/com/example/mody/domain/image/controller/S3Controller.java
@@ -1,0 +1,53 @@
+package com.example.mody.domain.image.controller;
+
+import com.example.mody.domain.auth.security.CustomUserDetails;
+import com.example.mody.domain.image.dto.response.PresignedUrlRequest;
+import com.example.mody.domain.image.dto.response.PresignedUrlResponse;
+import com.example.mody.domain.image.dto.response.S3UrlResponse;
+import com.example.mody.domain.image.service.S3Service;
+import com.example.mody.global.common.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "S3 API", description = "S3 사진 업로드 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/image")
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping(value = "/upload")
+    @Operation(summary = "presigned url 생성 API", description = "파일 업로드(put) presigned url을 생성하는 API 입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    public BaseResponse<List<PresignedUrlResponse>> getPresignedUrl(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody PresignedUrlRequest request
+    ) {
+        List<PresignedUrlResponse> presignedUrlResponse = s3Service.getPresignedUrls(customUserDetails.getMember().getId(), request.getFilenames());
+        return BaseResponse.onSuccess(presignedUrlResponse);
+    }
+
+
+    // 테스트용
+    @GetMapping(value = "/getS3Url")
+    @Operation(summary = "S3 URL 조회 - 테스트용으로 API 연동 시 신경 안 써도 되는 API 입니다.",
+            description = "프론트에서 S3에 파일 업로드 후 반환하는 S3 URL을 서버에서 생성해 확인해보는 테스트용 API 입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    public BaseResponse<S3UrlResponse> getS3Url(@RequestParam String key) {
+        S3UrlResponse s3UrlResponse = s3Service.getS3Url(key);
+        return BaseResponse.onSuccess(s3UrlResponse);
+    }
+
+}

--- a/src/main/java/com/example/mody/domain/image/controller/S3Controller.java
+++ b/src/main/java/com/example/mody/domain/image/controller/S3Controller.java
@@ -1,10 +1,11 @@
 package com.example.mody.domain.image.controller;
 
 import com.example.mody.domain.auth.security.CustomUserDetails;
-import com.example.mody.domain.image.dto.response.PresignedUrlRequest;
+import com.example.mody.domain.image.dto.request.PresignedUrlRequest;
 import com.example.mody.domain.image.dto.response.PresignedUrlResponse;
 import com.example.mody.domain.image.dto.response.S3UrlResponse;
 import com.example.mody.domain.image.service.S3Service;
+import com.example.mody.domain.post.service.PostQueryService;
 import com.example.mody.global.common.base.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -37,10 +38,9 @@ public class S3Controller {
         return BaseResponse.onSuccess(presignedUrlResponse);
     }
 
-
-    // 테스트용
+    // 테스트용(실제 사용 X)
     @GetMapping(value = "/getS3Url")
-    @Operation(summary = "S3 URL 조회 - 테스트용으로 API 연동 시 신경 안 써도 되는 API 입니다.",
+    @Operation(summary = "자체 S3 URL 조회 - 테스트용으로 API 연동 시 신경 안 써도 되는 API 입니다.",
             description = "프론트에서 S3에 파일 업로드 후 반환하는 S3 URL을 서버에서 생성해 확인해보는 테스트용 API 입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")

--- a/src/main/java/com/example/mody/domain/image/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/example/mody/domain/image/dto/request/PresignedUrlRequest.java
@@ -1,4 +1,4 @@
-package com.example.mody.domain.image.dto.response;
+package com.example.mody.domain.image.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;

--- a/src/main/java/com/example/mody/domain/image/dto/response/PresignedUrlRequest.java
+++ b/src/main/java/com/example/mody/domain/image/dto/response/PresignedUrlRequest.java
@@ -1,0 +1,19 @@
+package com.example.mody.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * S3 presigned url 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class PresignedUrlRequest {
+    @Schema(description = "업로드할 파일 목록", example = "[\"a.png\", \"b.jpg\"]")
+    private List<String> filenames;
+}

--- a/src/main/java/com/example/mody/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/example/mody/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,27 @@
+package com.example.mody.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+/**
+ * S3 presigned url 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@EqualsAndHashCode
+@Schema(description = "S3 Presigned Url 응답 DTO")
+public class PresignedUrlResponse {
+
+    @Schema(description = "S3 presigned url", example = "https://{bucket-name}.s3.{region}.amazonaws.com/{object-key}?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date={timestamp}&X-Amz-SignedHeaders=host&X-Amz-Expires={expires}&X-Amz-Credential={credential}&X-Amz-Signature={signature}")
+    private String presignedUrl;
+    @Schema(description = "key 값", example = "{folder}/{memberId}/{uuid}/{filename}")
+    private String key;
+
+    public static PresignedUrlResponse from(String preSignedUrl, String key){
+        PresignedUrlResponse response = new PresignedUrlResponse();
+        response.setPresignedUrl(preSignedUrl);
+        response.setKey(key);
+        return response;
+    }
+}

--- a/src/main/java/com/example/mody/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/example/mody/domain/image/dto/response/PresignedUrlResponse.java
@@ -10,12 +10,12 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode
-@Schema(description = "S3 Presigned Url 응답 DTO")
+@Schema(description = "S3 presigned url 응답 DTO")
 public class PresignedUrlResponse {
 
     @Schema(description = "S3 presigned url", example = "https://{bucket-name}.s3.{region}.amazonaws.com/{object-key}?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date={timestamp}&X-Amz-SignedHeaders=host&X-Amz-Expires={expires}&X-Amz-Credential={credential}&X-Amz-Signature={signature}")
     private String presignedUrl;
-    @Schema(description = "key 값", example = "{folder}/{memberId}/{uuid}/{filename}")
+    @Schema(description = "S3 key 값", example = "{folder}/{memberId}/{uuid}/{filename}")
     private String key;
 
     public static PresignedUrlResponse from(String preSignedUrl, String key){

--- a/src/main/java/com/example/mody/domain/image/dto/response/S3UrlResponse.java
+++ b/src/main/java/com/example/mody/domain/image/dto/response/S3UrlResponse.java
@@ -6,11 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * S3 url 응답 DTO
+ */
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Schema(description = "S3 Url 응답 DTO")
+@Schema(description = "S3 url 응답 DTO")
 public class S3UrlResponse {
 
     @Schema(description = "S3 url", example = "https://{bucket-name}.s3.{region}.amazonaws.com/{object-key}")

--- a/src/main/java/com/example/mody/domain/image/dto/response/S3UrlResponse.java
+++ b/src/main/java/com/example/mody/domain/image/dto/response/S3UrlResponse.java
@@ -1,0 +1,24 @@
+package com.example.mody.domain.image.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "S3 Url 응답 DTO")
+public class S3UrlResponse {
+
+    @Schema(description = "S3 url", example = "https://{bucket-name}.s3.{region}.amazonaws.com/{object-key}")
+    private String s3Url;
+
+    public static S3UrlResponse from(String s3Url){
+        S3UrlResponse response = new S3UrlResponse();
+        response.setS3Url(s3Url);
+        return response;
+    }
+}

--- a/src/main/java/com/example/mody/domain/image/service/S3Service.java
+++ b/src/main/java/com/example/mody/domain/image/service/S3Service.java
@@ -1,0 +1,79 @@
+package com.example.mody.domain.image.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.example.mody.domain.image.dto.response.PresignedUrlResponse;
+import com.example.mody.domain.image.dto.response.S3UrlResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class S3Service {
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public List<PresignedUrlResponse> getPresignedUrls(Long memberId, List<String> filenames) {
+        // 게시물당 하나의 UUID를 생성
+        String uuid = UUID.randomUUID().toString();
+
+        List<PresignedUrlResponse> presignedUrls = new ArrayList<>();
+        for (String filename : filenames) {
+            String key = String.format("deploy/%d/%s/%s", memberId, uuid, filename); // 테스트용 deploy 폴더, 추후 post 폴더로 변경 예정
+            Date expiration = getExpiration();
+            GeneratePresignedUrlRequest generatePresignedUrlRequest = generatePresignedUrl(key, expiration);
+
+            URL url = amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest);
+            presignedUrls.add(PresignedUrlResponse.from(url.toExternalForm(), key));
+        }
+        return presignedUrls;
+    }
+
+    // 업로드용(put) presigned url 생성하는 메서드
+    private GeneratePresignedUrlRequest generatePresignedUrl(String key, Date expiration) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest
+                = new GeneratePresignedUrlRequest(bucket, key)
+                .withMethod(HttpMethod.PUT)
+                .withKey(key)
+                .withExpiration(expiration);
+        generatePresignedUrlRequest.addRequestParameter(
+                Headers.S3_CANNED_ACL,
+                CannedAccessControlList.PublicRead.toString());
+        return generatePresignedUrlRequest;
+    }
+
+    // 유효 기간 설정
+    private static Date getExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 60; // 1시간 설정
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+    // 프론트에서 전달받은 key를 이용해 S3 URL 생성 및 반환(테스트용)
+    public S3UrlResponse getS3Url(String key) {
+        String s3Url = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+        log.info("s3Url: {}", s3Url);
+        return S3UrlResponse.from(s3Url);
+    }
+}

--- a/src/main/java/com/example/mody/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/example/mody/domain/post/dto/request/PostCreateRequest.java
@@ -33,11 +33,9 @@ public class PostCreateRequest {
 	private Boolean isPublic;
 
 	@Schema(
-		description = "파일명, 파일 크기, S3 URL 목록",
-		example = "[\"" +
-			"https://mody-s3-bucket.s3.ap-northeast-2.amazonaws.com/filea8500f7a-c902-4f64-b605-7bc6247b4e75\", " +
-			"https://mody-s3-bucket.s3.ap-northeast-2.amazonaws.com/fileb8500f7a-c902-4f64-b605-7bc6247b4e76\"" +
-			"]"
+		description = "S3 URL 목록",
+		example = "[\"https://{bucket-name}.s3.{region}.amazonaws.com/{object-key1}\", " +
+				"\"https://{bucket-name}.s3.{region}.amazonaws.com/{object-key2}\"]"
 	)
-	private List<String> files;
+	private List<String> s3Urls;
 }

--- a/src/main/java/com/example/mody/domain/post/entity/PostImage.java
+++ b/src/main/java/com/example/mody/domain/post/entity/PostImage.java
@@ -23,8 +23,8 @@ public class PostImage extends BaseEntity {
     @Column(nullable = false)
     private String url;
 
-    public PostImage(Post post, String url){
+    public PostImage(Post post, String s3Url){
         this.post = post;
-        this.url = url;
+        this.url = s3Url;
     }
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostCommandServiceImpl.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 
 import com.example.mody.domain.file.repository.BackupFileRepository;
 import com.example.mody.domain.post.dto.request.PostUpdateRequest;
-import com.example.mody.domain.post.dto.response.PostResponse;
 import com.example.mody.domain.post.entity.mapping.PostReport;
 import com.example.mody.domain.post.repository.PostReportRepository;
 import org.springframework.stereotype.Service;
@@ -20,17 +19,14 @@ import com.example.mody.domain.bodytype.service.BodyTypeService;
 import com.example.mody.domain.exception.BodyTypeException;
 import com.example.mody.domain.exception.MemberException;
 import com.example.mody.domain.exception.PostException;
-import com.example.mody.domain.file.repository.BackupFileRepository;
 import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.member.repository.MemberRepository;
 import com.example.mody.domain.post.dto.request.PostCreateRequest;
 import com.example.mody.domain.post.entity.Post;
 import com.example.mody.domain.post.entity.PostImage;
 import com.example.mody.domain.post.entity.mapping.MemberPostLike;
-import com.example.mody.domain.post.entity.mapping.PostReport;
 import com.example.mody.domain.post.repository.MemberPostLikeRepository;
 import com.example.mody.domain.post.repository.PostImageRepository;
-import com.example.mody.domain.post.repository.PostReportRepository;
 import com.example.mody.domain.post.repository.PostRepository;
 import com.example.mody.global.common.exception.code.status.MemberErrorStatus;
 import com.example.mody.global.common.exception.code.status.PostErrorStatus;
@@ -66,8 +62,8 @@ public class PostCommandServiceImpl implements PostCommandService {
 			postCreateRequest.getContent(),
 			postCreateRequest.getIsPublic());
 
-		postCreateRequest.getFiles().forEach(file -> {
-			PostImage postImage = new PostImage(post, file);
+		postCreateRequest.getS3Urls().forEach(s3Url -> {
+			PostImage postImage = new PostImage(post, s3Url);
 			post.getImages().add(postImage);
 		});
 

--- a/src/main/java/com/example/mody/global/common/exception/code/status/S3ErrorStatus.java
+++ b/src/main/java/com/example/mody/global/common/exception/code/status/S3ErrorStatus.java
@@ -1,0 +1,56 @@
+package com.example.mody.global.common.exception.code.status;
+
+import com.example.mody.global.common.exception.code.BaseCodeDto;
+import com.example.mody.global.common.exception.code.BaseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum S3ErrorStatus implements BaseCodeInterface {
+
+	// 버킷 관련 오류
+	BUCKET_NOT_FOUND(HttpStatus.NOT_FOUND, "S3_404", "지정된 S3 버킷을 찾을 수 없습니다."),
+	BUCKET_ACCESS_DENIED(HttpStatus.FORBIDDEN, "S3_403", "S3 버킷에 대한 접근이 거부되었습니다."),
+	BUCKET_NAME_INVALID(HttpStatus.BAD_REQUEST, "S3_400", "S3 버킷 이름이 유효하지 않습니다."),
+	BUCKET_REGION_MISMATCH(HttpStatus.BAD_REQUEST, "S3_400", "요청한 S3 버킷이 지정된 리전과 일치하지 않습니다."),
+
+	// 객체(파일) 관련 오류
+	OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "S3_404", "요청한 S3 객체를 찾을 수 없습니다."),
+	OBJECT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "S3_403", "S3 객체에 대한 접근이 거부되었습니다."),
+	OBJECT_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_500", "S3 객체 업로드 중 오류가 발생했습니다."),
+	OBJECT_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_500", "S3 객체 다운로드 중 오류가 발생했습니다."),
+	OBJECT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_500", "S3 객체 삭제 중 오류가 발생했습니다."),
+	OBJECT_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "S3_400", "업로드할 파일 크기가 허용된 한도를 초과했습니다."),
+	OBJECT_INVALID_KEY(HttpStatus.BAD_REQUEST, "S3_400", "S3 객체 키가 유효하지 않습니다."),
+
+	// presigned url 관련 오류
+	PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3_500", "S3 Presigned URL 생성 중 오류가 발생했습니다."),
+	PRESIGNED_URL_EXPIRED(HttpStatus.BAD_REQUEST, "S3_400", "요청한 Presigned URL이 만료되었습니다."),
+	PRESIGNED_URL_INVALID(HttpStatus.BAD_REQUEST, "S3_400", "요청한 Presigned URL이 유효하지 않습니다."),
+
+	// 인증 및 권한 관련 오류
+	CREDENTIALS_INVALID(HttpStatus.UNAUTHORIZED, "S3_401", "S3 접근을 위한 자격 증명이 유효하지 않습니다."),
+	PERMISSION_DENIED(HttpStatus.FORBIDDEN, "S3_403", "S3 작업에 대한 권한이 부족합니다."),
+
+	// 기타 S3 관련 오류
+	NETWORK_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3_500", "S3 서비스와의 네트워크 연결에 문제가 발생했습니다."),
+	UNKNOWN_S3_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3_500", "알 수 없는 S3 오류가 발생했습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final boolean isSuccess = false;
+	private final String code;
+	private final String message;
+
+	@Override
+	public BaseCodeDto getCode() {
+		return BaseCodeDto.builder()
+			.httpStatus(httpStatus)
+			.isSuccess(isSuccess)
+			.code(code)
+			.message(message)
+			.build();
+	}
+}

--- a/src/main/java/com/example/mody/global/config/S3Config.java
+++ b/src/main/java/com/example/mody/global/config/S3Config.java
@@ -1,13 +1,15 @@
 package com.example.mody.global.config;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
 
-//@Configuration
+@Configuration
 public class S3Config {
     @Value("${cloud.aws.credentials.accessKey}")
     private String accessKey;
@@ -19,11 +21,12 @@ public class S3Config {
     private String region;
 
     @Bean
-    public AmazonS3Client amazonS3Client() {
-        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#59 

## 📝 요약(Summary)

presigned url을 생성하여 프론트로 보내주고, 프론트에서 S3에 파일 업로드를 합니다. 그리고 게시물 등록시 S3 url도 같이 보내주고 post_image에 값을 저장하도록 작성하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
사용자와 게시글에 따라 S3의 presigned url과 key 값을 따로 만들어 관리합니다. {folder}/{memberId}/{uuid}/{filename} 로 key 값을 관리하여 어떤 사용자가 무슨 게시글에서 등록한 사진인지 편하게 관리할 수 있습니다.

### 흐름
1. 업로드 하는 파일 개수만큼 presigned url 생성 후 리스트로 반환
2. 게시글 업로드 시에 S3 url도 리스트로 같이 받음
3. Post 테이블 생성하면서 PostImage도 같이 생성하고, 필드에 S3 url 저장

### 스크린샷
1. presigned url과 key 값을 리스트로 반환
![image](https://github.com/user-attachments/assets/c2cadf09-dc32-4ca7-9a71-ad17bb6a4a92)
![image](https://github.com/user-attachments/assets/84f3a5e3-0b0e-444d-924c-98c58d69850d)
2. 프론트에서 해당 presigned url로 파일 업로드(Postman에서 테스트 진행)
![image](https://github.com/user-attachments/assets/7b6ad2ec-2f83-4827-bed1-2b1f91f7d9b9)
![image](https://github.com/user-attachments/assets/e8a31a1e-b2c5-47d5-b385-ac9ac29e241d)
3. S3에 잘 저장되었음을 확인 가능
![image](https://github.com/user-attachments/assets/1c8510dc-d1d7-4959-85e7-ed4c99b9487a)
4. 게시글 작성 시 해당 S3 url도 포함해서 요청
![image](https://github.com/user-attachments/assets/985b210d-cbcd-4c3f-b0d9-52c55f35a433)
![image](https://github.com/user-attachments/assets/2fc14a0b-ab9e-4f15-8b20-84d0703c3250)
5. post_image 테이블 저장 인
![image](https://github.com/user-attachments/assets/7019a84e-4ac3-4767-9ca7-1dde54fe6ebe)

+ 이미지 수정, 삭제 관련해서는 확정된 내용이 없어 정해지면 추후 구현하겠습니다!
## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
