### PR TITLE
🔨 [Hotfix] #80 - 좋아요 누른 게시글 조회 오류 수정

### DIFF
--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
@@ -122,7 +122,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                 .from(qPost)
                 .leftJoin(qMemberPostLike).on(qMemberPostLike.post.eq(qPost).and(qMemberPostLike.member.eq(member)))
                 .where(predicate)
-                .orderBy(qPost.createdAt.desc())
+                .orderBy(qMemberPostLike.createdAt.desc())
                 .limit(size+1) //하나 더 가져와서 다음 요소가 존재하는지 확인
                 .fetch();
 
@@ -131,7 +131,6 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                 .leftJoin(qPost.member, qMember)
                 .leftJoin(qPost.images, qPostImage)
                 .where(qPost.id.in(postIds))
-                .orderBy(qPost.createdAt.desc())
                 .transform(GroupBy.groupBy(qPost.id).as(
                         Projections.constructor(PostResponse.class,
                                 qPost.id,
@@ -145,7 +144,10 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                                 GroupBy.list(qPostImage)
                         )));
 
-        List<PostResponse> postResponses = new ArrayList<>(postResponseMap.values());
+        List<PostResponse> postResponses = postIds.stream()
+                .map(postResponseMap::get)
+                .filter(Objects::nonNull)
+                .toList();
 
         return new LikedPostsResponse(
                 hasNext.apply(postResponses, size),

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
@@ -57,10 +57,13 @@ public class PostQueryServiceImpl implements PostQueryService {
         }
         LikedPostsResponse likedPostsResponse = postRepository.getLikedPosts(cursor, size, member);
 
-        PostResponse postResponse = likedPostsResponse.postResponses().getLast();
-        MemberPostLike memberPostLike = findByMemberAndPostId(member, postResponse.getPostId());
+        Optional<Long> nextLike = Optional.empty();
+        if(likedPostsResponse.hasNext()){
+            PostResponse postResponse = likedPostsResponse.postResponses().getLast();
+            nextLike = Optional.ofNullable(findByMemberAndPostId(member, postResponse.getPostId()).getId());
+        }
 
-        return PostListResponse.of(likedPostsResponse.hasNext(), likedPostsResponse.postResponses(), memberPostLike.getId());
+        return PostListResponse.of(likedPostsResponse.hasNext(), likedPostsResponse.postResponses(), nextLike.orElse(null));
     }
 
     @Override


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
Closes #80 
## 📝 요약(Summary)
- 좋아요 누른 게시글 조회 오류 수정
- 다음 좋아요가 존재하지 않음에도 cursor를 위해 이를 찾으려하는 문제 해결
  - getLast 메서드를 사용할 때 list가 비어있으면 Exception이 발생함.
- 정렬 기준이 최근 좋아요를 누른 순서가 아니고, post 의 생성 순서로 조회되던 문제 해결

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
