### PR TITLE
✨ [FEATURE] #85 - 프로필 사진 업로드, 이미지 삭제 구현

### DIFF
--- a/src/main/java/com/example/mody/domain/auth/dto/request/MemberRegistrationRequest.java
+++ b/src/main/java/com/example/mody/domain/auth/dto/request/MemberRegistrationRequest.java
@@ -59,7 +59,7 @@ public class MemberRegistrationRequest {
 
 	@Schema(
 		description = "프로필 이미지 URL",
-		example = "https://example.com/profile.jpg",
+		example = "https://my-bucket.s3.amazonaws.com/path/to/file.jpg",
 		required = false
 	)
 	private String profileImageUrl;

--- a/src/main/java/com/example/mody/domain/image/controller/S3Controller.java
+++ b/src/main/java/com/example/mody/domain/image/controller/S3Controller.java
@@ -1,11 +1,10 @@
 package com.example.mody.domain.image.controller;
 
 import com.example.mody.domain.auth.security.CustomUserDetails;
-import com.example.mody.domain.image.dto.request.PresignedUrlRequest;
+import com.example.mody.domain.image.dto.request.PostPresignedUrlRequest;
+import com.example.mody.domain.image.dto.request.ProfilePresignedUrlRequest;
 import com.example.mody.domain.image.dto.response.PresignedUrlResponse;
-import com.example.mody.domain.image.dto.response.S3UrlResponse;
 import com.example.mody.domain.image.service.S3Service;
-import com.example.mody.domain.post.service.PostQueryService;
 import com.example.mody.global.common.base.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -28,8 +27,8 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
-    @PostMapping(value = "/upload")
-    @Operation(summary = "presigned url 생성 API", description = "파일 업로드(put) presigned url을 생성하는 API 입니다.")
+    @PostMapping(value = "/upload/posts")
+    @Operation(summary = "게시글 presigned url 생성 API", description = "게시글 파일 업로드(put) presigned url을 생성하는 API 입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",description = "presigned url 생성을 성공하였습니다."),
             @ApiResponse(
@@ -81,11 +80,72 @@ public class S3Controller {
                     )
             ),
     })
-    public BaseResponse<List<PresignedUrlResponse>> getPresignedUrl(
+    public BaseResponse<List<PresignedUrlResponse>> getPostPresignedUrl(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @Valid @RequestBody PresignedUrlRequest request
+            @Valid @RequestBody PostPresignedUrlRequest request
     ) {
-        List<PresignedUrlResponse> presignedUrlResponse = s3Service.getPresignedUrls(customUserDetails.getMember().getId(), request.getFilenames());
+        List<PresignedUrlResponse> presignedUrlResponse = s3Service.getPostPresignedUrls(customUserDetails.getMember().getId(), request.getFilenames());
+        return BaseResponse.onSuccess(presignedUrlResponse);
+    }
+
+    @PostMapping(value = "/upload/profiles")
+    @Operation(summary = "프로필 사진 presigned url 생성 API", description = "프로필 사진 파일 업로드(put) presigned url을 생성하는 API 입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",description = "presigned url 생성을 성공하였습니다."),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Access Token이 필요합니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+						{
+							"timestamp": "2025-01-26T15:15:54.334Z",
+							"code": "COMMON401",
+							"message": "인증이 필요합니다."
+						}
+						"""
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "S3 버킷을 찾을 수 없습니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+						{
+							"timestamp": "2025-01-26T15:15:54.334Z",
+							"code": "S3_404",
+							"message": "지정된 S3 버킷을 찾을 수 없습니다."
+						}
+						"""
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "presigned url 생성을 실패하였습니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+						{
+							"timestamp": "2025-01-26T15:15:54.334Z",
+							"code": "S3_500",
+							"message": "S3 presigned url 생성 중 오류가 발생했습니다."
+						}
+						"""
+                            )
+                    )
+            ),
+    })
+    public BaseResponse<PresignedUrlResponse> getProfilePresignedUrl(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody ProfilePresignedUrlRequest request
+    ) {
+        PresignedUrlResponse presignedUrlResponse = s3Service.getProfilePresignedUrl(customUserDetails.getMember().getId(), request.getFilename());
         return BaseResponse.onSuccess(presignedUrlResponse);
     }
 

--- a/src/main/java/com/example/mody/domain/image/dto/request/PostPresignedUrlRequest.java
+++ b/src/main/java/com/example/mody/domain/image/dto/request/PostPresignedUrlRequest.java
@@ -1,0 +1,19 @@
+package com.example.mody.domain.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 게시글 S3 presigned url 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostPresignedUrlRequest {
+    @Schema(description = "업로드할 파일 목록", example = "[\"a.png\", \"b.jpg\"]")
+    private List<String> filenames;
+}

--- a/src/main/java/com/example/mody/domain/image/dto/request/ProfilePresignedUrlRequest.java
+++ b/src/main/java/com/example/mody/domain/image/dto/request/ProfilePresignedUrlRequest.java
@@ -8,12 +8,12 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * S3 presigned url 요청 DTO
+ * 프로필 사진 S3 presigned url 요청 DTO
  */
 @Getter
 @Setter
 @NoArgsConstructor
-public class PresignedUrlRequest {
-    @Schema(description = "업로드할 파일 목록", example = "[\"a.png\", \"b.jpg\"]")
-    private List<String> filenames;
+public class ProfilePresignedUrlRequest {
+    @Schema(description = "업로드할 파일", example = "a.png")
+    private String filename;
 }

--- a/src/main/java/com/example/mody/domain/image/service/S3Service.java
+++ b/src/main/java/com/example/mody/domain/image/service/S3Service.java
@@ -42,7 +42,7 @@ public class S3Service {
 
         List<PresignedUrlResponse> presignedUrls = new ArrayList<>();
         for (String filename : filenames) {
-            String key = String.format("deploy/%d/%s/%s", memberId, uuid, filename); // 테스트용 deploy 폴더, 추후 post 폴더로 변경 예정
+            String key = String.format("deploy/%d/%s%s", memberId, uuid, filename); // 테스트용 deploy 폴더, 추후 post 폴더로 변경 예정
             Date expiration = getExpiration(); // 유효 기간
             GeneratePresignedUrlRequest generatePresignedUrlRequest = generatePresignedUrl(key, expiration);
 
@@ -54,7 +54,7 @@ public class S3Service {
 
     public PresignedUrlResponse getProfilePresignedUrl(Long memberId, String filename) {
         // key값 설정(profile 경로 + 멤버ID + 랜덤 값 + filename)
-        String key = String.format("profile/%d/%s/%s", memberId, UUID.randomUUID(), filename);
+        String key = String.format("profile/%d/%s%s", memberId, UUID.randomUUID(), filename);
 
         // 유효 기간
         Date expiration = getExpiration();

--- a/src/main/java/com/example/mody/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/mody/domain/post/controller/PostController.java
@@ -181,9 +181,9 @@ public class PostController {
             @Parameter(name = "postId", description = "게시글 아이디, path variable 입니다")
     })
     public BaseResponse<Void> deletePost(
-            @PathVariable Long postsId,
+            @PathVariable Long postId,
 			@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        postCommandService.deletePost(postsId, customUserDetails.getMember());
+        postCommandService.deletePost(postId, customUserDetails.getMember());
         return BaseResponse.onSuccessDelete(null);
     }
 

--- a/src/main/java/com/example/mody/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostCommandServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 import com.example.mody.domain.file.repository.BackupFileRepository;
 import com.example.mody.domain.file.service.FileService;
+import com.example.mody.domain.image.service.S3Service;
 import com.example.mody.domain.post.dto.request.PostUpdateRequest;
 import com.example.mody.domain.post.entity.mapping.PostReport;
 import com.example.mody.domain.post.repository.PostReportRepository;
@@ -51,7 +52,8 @@ public class PostCommandServiceImpl implements PostCommandService {
 	private final PostReportRepository postReportRepository;
 	private final BodyTypeService bodyTypeService;
 	private final FileService fileService;
-  private final RestTemplate restTemplate;
+	private final RestTemplate restTemplate;
+	private final S3Service s3Service;
 
 	/**
 	 * 게시글 작성 비즈니스 로직. BodyType은 요청 유저의 가장 마지막 BodyType을 적용함. 유저의 BodyType이 존재하지 않을 경우 예외 발생.
@@ -167,10 +169,14 @@ public class PostCommandServiceImpl implements PostCommandService {
 	@Transactional
 	protected void delete(Post post) {
 		List<String> postImageUrls = postImageRepository.findPostImageUrlByPostId(post.getId());
+
+		// S3 파일 삭제
+		s3Service.deleteFile(postImageUrls);
+
+		// DB에서 Post 관련 데이터 삭제
 		fileService.deleteByS3Urls(postImageUrls);
-    	postReportRepository.deleteAllByPost(post);
-		// @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)로 설정해놔서 postId에 해당하는 PostImage 전부 삭제됨
-		postRepository.deleteById(post.getId());
+		postReportRepository.deleteAllByPost(post);
+		postRepository.deleteById(post.getId()); // (cascade = CascadeType.ALL, orphanRemoval = true) -> postId에 해당하는 PostImage 전부 삭제됨
 	}
 
 	private void checkAuthorization(Member member, Post post){

--- a/src/main/java/com/example/mody/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostCommandServiceImpl.java
@@ -168,7 +168,8 @@ public class PostCommandServiceImpl implements PostCommandService {
 	protected void delete(Post post) {
 		List<String> postImageUrls = postImageRepository.findPostImageUrlByPostId(post.getId());
 		fileService.deleteByS3Urls(postImageUrls);
-    postReportRepository.deleteAllByPost(post);
+    	postReportRepository.deleteAllByPost(post);
+		// @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)로 설정해놔서 postId에 해당하는 PostImage 전부 삭제됨
 		postRepository.deleteById(post.getId());
 	}
 


### PR DESCRIPTION
## #️⃣ Issue Number

#85

## 📝 요약(Summary)

1. 프로필 사진은 한 장만 업로드 가능하기 때문에, 프사 업로드용 presigned url 생성 api를 구현하였습니다.
2. 게시글 삭제 시 PostImage도 같이 삭제되도록 구현하는 과정에서 게시글 삭제 api의 path variable이 잘못 적혀있어 수정하였습니다.
3. 게시글 삭제 시 S3의 이미지도 삭제되도록 구현하였습니다. 이 과정에서 access key와 secret key 값이 수정되었으니, 노션에서 확인 후 각자 로컬 환경에도 수정 부탁드립니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
1. 회원 정보 수정은 구현할지 말지 아직 안 정해졌다고 해서 프로필 사진 삭제 및 수정은 아직 구현하지 않았습니다.
2.  access key, secret key 값 수정 됐습니다!

### 스크린샷
#### post_id가 7인 게시글 삭제 전
* post 테이블
![image](https://github.com/user-attachments/assets/4e28317d-3a7c-4e1c-bc24-37f9f4d0c548)
* post_image 테이블
![image](https://github.com/user-attachments/assets/7a9a8d46-b2ae-4acd-8904-b074dba90a34)
* S3 bucket
![image](https://github.com/user-attachments/assets/8810c342-8050-4467-803e-2e0716ce1f00)
#### 게시글 삭제 테스트(post_Id가 7인 게시글 삭제)
![image](https://github.com/user-attachments/assets/54fc7e12-a856-4d11-9817-7863c54ba5c3)
![image](https://github.com/user-attachments/assets/f0e2e388-ce61-403f-964d-3bc4a6f83999)
#### 결과
* post 테이블
![image](https://github.com/user-attachments/assets/770a9fbc-b9ba-40b2-86d1-6b2cf98fa396)
* post_image 테이블
![image](https://github.com/user-attachments/assets/05b4d2fa-0511-43bc-86f4-4a08badfd671)
* S3 bucket
![image](https://github.com/user-attachments/assets/8150d5d8-f6b1-4d20-85f6-cb4263f75a29)

-> 의도한대로 post 테이블, post_image 테이블, S3 파일이 삭제되었음을 확인 가능.



## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
