### PR TITLE
🔨 [HOTFIX] #102 - 체형 분석 결과 조회 수정

### DIFF
--- a/src/main/java/com/example/mody/domain/bodytype/repository/MemberBodyTypeRepository.java
+++ b/src/main/java/com/example/mody/domain/bodytype/repository/MemberBodyTypeRepository.java
@@ -12,5 +12,5 @@ public interface MemberBodyTypeRepository extends JpaRepository<MemberBodyType, 
     Optional<MemberBodyType> findTopByMemberOrderByCreatedAt(Member member);
     Optional<MemberBodyType> findMemberBodyTypeByMember(Member member);
     Long countAllByMember(Member member);
-
+    Optional<MemberBodyType> findTopByMemberOrderByCreatedAtDesc(Member member);
 }

--- a/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/bodytype/service/memberbodytype/MemberBodyTypeQueryServiceImpl.java
@@ -36,7 +36,7 @@ public class MemberBodyTypeQueryServiceImpl implements MemberBodyTypeQueryServic
 
     // Member로 MemberBodyType 조회
     private MemberBodyType getMemberBodyType(Member member) {
-        Optional<MemberBodyType> optionalMemberBodyType = memberBodyTypeRepository.findMemberBodyTypeByMember(member);
+        Optional<MemberBodyType> optionalMemberBodyType =  memberBodyTypeRepository.findTopByMemberOrderByCreatedAtDesc(member);
         return optionalMemberBodyType.orElseThrow(() -> new BodyTypeException(BodyTypeErrorStatus.MEMBER_BODY_TYPE_NOT_FOUND));
     }
 }


### PR DESCRIPTION
체형 분석 결과 조회 시 생긴 문제를 해결하였습니다.

## #️⃣ Issue Number

#102 

## 📝 요약(Summary)

체형 분석 결과가 여러 개일 때 체형 분석 결과를 못 받아오는 문제를 해결하고, 가장 최신 체형 분석 결과를 받아오도록 수정하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

### 스크린샷
1. MemberBodyType 여러 개 존재
![image](https://github.com/user-attachments/assets/eda954d2-f9d1-4792-bcd1-458c42532547)
2. 그 중 가장 최신 데이터 조회
![image](https://github.com/user-attachments/assets/f5664a48-4b88-4c23-89e9-6bb518575f54)


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
