### PR TITLE
♻️ [REFACTOR] #131 - 게시글 조회 API 리팩토링

### DIFF
--- a/src/main/java/com/example/mody/domain/bodytype/entity/BodyType.java
+++ b/src/main/java/com/example/mody/domain/bodytype/entity/BodyType.java
@@ -1,6 +1,7 @@
 package com.example.mody.domain.bodytype.entity;
 
 import com.example.mody.domain.bodytype.entity.mapping.MemberBodyType;
+import com.example.mody.domain.member.entity.Member;
 import com.example.mody.global.common.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -9,6 +10,7 @@ import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -30,4 +32,20 @@ public class BodyType extends BaseEntity {
 
     @OneToMany(mappedBy = "bodyType", cascade = CascadeType.ALL)
     private List<MemberBodyType> memberBodyTypeList = new ArrayList<>();
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BodyType that)) {
+            return false;
+        }
+        return Objects.equals(that.getId(), this.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/com/example/mody/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/mody/domain/post/controller/PostController.java
@@ -1,11 +1,9 @@
 package com.example.mody.domain.post.controller;
 
 
-import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.member.repository.MemberRepository;
 import com.example.mody.domain.post.dto.request.PostUpdateRequest;
 import com.example.mody.domain.post.dto.response.PostResponse;
-import com.example.mody.domain.post.entity.Post;
 import io.swagger.v3.oas.annotations.Parameters;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,9 +18,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.mody.domain.auth.security.CustomUserDetails;
-import com.example.mody.domain.member.repository.MemberRepository;
 import com.example.mody.domain.post.dto.request.PostCreateRequest;
-import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.dto.response.PostResponses;
 import com.example.mody.domain.post.exception.annotation.ExistsPost;
 import com.example.mody.domain.post.service.PostCommandService;
 import com.example.mody.domain.post.service.PostQueryService;
@@ -30,7 +27,6 @@ import com.example.mody.global.common.base.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -61,12 +57,12 @@ public class PostController {
 			description = "게시글 목록 조회 성공"
 		)
 	})
-	public BaseResponse<PostListResponse> getAllPosts(
+	public BaseResponse<PostResponses> getAllPosts(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@RequestParam(name = "cursor", required = false) Long cursor,
 		@RequestParam(name = "size", defaultValue = "15") Integer size) {
-		PostListResponse postListResponse = postQueryService.getPosts(customUserDetails.getMember(), size, cursor);
-		return BaseResponse.onSuccess(postListResponse);
+		PostResponses postResponses = postQueryService.getPosts(customUserDetails.getMember(), size, cursor);
+		return BaseResponse.onSuccess(postResponses);
 	}
 
 	/**
@@ -272,12 +268,12 @@ public class PostController {
 			description = "게시글 목록 조회 성공"
 		)
 	})
-	public BaseResponse<PostListResponse> getLikedPosts(
+	public BaseResponse<PostResponses> getLikedPosts(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@RequestParam(name = "cursor", required = false) Long cursor,
 		@RequestParam(name = "size", defaultValue = "15") Integer size) {
-		PostListResponse postListResponse = postQueryService.getLikedPosts(customUserDetails.getMember(), size, cursor);
-		return BaseResponse.onSuccess(postListResponse);
+		PostResponses postResponses = postQueryService.getLikedPosts(customUserDetails.getMember(), size, cursor);
+		return BaseResponse.onSuccess(postResponses);
 	}
 
 	@GetMapping("/me")
@@ -288,12 +284,12 @@ public class PostController {
 			description = "게시글 목록 조회 성공"
 		)
 	})
-	public BaseResponse<PostListResponse> getMyPosts(
+	public BaseResponse<PostResponses> getMyPosts(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@RequestParam(name = "cursor", required = false) Long cursor,
 		@RequestParam(name = "size", defaultValue = "15") Integer size) {
-		PostListResponse postListResponse = postQueryService.getMyPosts(customUserDetails.getMember(), size, cursor);
-		return BaseResponse.onSuccess(postListResponse);
+		PostResponses postResponses = postQueryService.getMyPosts(customUserDetails.getMember(), size, cursor);
+		return BaseResponse.onSuccess(postResponses);
 	}
 
 	@PostMapping("/{postId}/reports")

--- a/src/main/java/com/example/mody/domain/post/dto/response/PostResponses.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/PostResponses.java
@@ -5,17 +5,18 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class PostListResponse {
+public class PostResponses {
     private List<PostResponse> postResponses;
     private CursorPagination cursorPagination;
 
-    public static PostListResponse of(Boolean hasNext, List<PostResponse> postResponses){
+    public static PostResponses of(Boolean hasNext, List<PostResponse> postResponses){
         Long cursor = hasNext ? postResponses.getLast().getPostId() : null;
-        return new PostListResponse(postResponses, new CursorPagination(hasNext, cursor));
+        return new PostResponses(postResponses, new CursorPagination(hasNext, cursor));
     }
 
     /**
@@ -25,7 +26,7 @@ public class PostListResponse {
      * @param cursor 반환하는 게시물 중 마지막 게시물과 클라이언트에 대한 likeId
      * @return
      */
-    public static PostListResponse of(Boolean hasNext, List<PostResponse> postResponses, Long cursor){
+    public static PostResponses of(Boolean hasNext, List<PostResponse> postResponses, Long cursor){
         Long newCursor = hasNext ? cursor : null;
         return new PostResponses(postResponses, new CursorPagination(hasNext, newCursor));
     }

--- a/src/main/java/com/example/mody/domain/post/dto/response/PostResponses.java
+++ b/src/main/java/com/example/mody/domain/post/dto/response/PostResponses.java
@@ -27,6 +27,14 @@ public class PostListResponse {
      */
     public static PostListResponse of(Boolean hasNext, List<PostResponse> postResponses, Long cursor){
         Long newCursor = hasNext ? cursor : null;
-        return new PostListResponse(postResponses, new CursorPagination(hasNext, newCursor));
+        return new PostResponses(postResponses, new CursorPagination(hasNext, newCursor));
+    }
+
+    public static PostResponses of(PostResponses firstPosts, PostResponses secondPosts){
+        List<PostResponse> newPostResponses = new ArrayList<>(
+                firstPosts.getPostResponses().size() + secondPosts.getPostResponses().size());
+        newPostResponses.addAll(firstPosts.getPostResponses());
+        newPostResponses.addAll(secondPosts.getPostResponses());
+        return new PostResponses(newPostResponses, secondPosts.cursorPagination);
     }
 }

--- a/src/main/java/com/example/mody/domain/post/entity/Post.java
+++ b/src/main/java/com/example/mody/domain/post/entity/Post.java
@@ -5,6 +5,7 @@ import static com.example.mody.domain.post.constant.PostConstant.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -13,22 +14,15 @@ import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.post.entity.mapping.MemberPostLike;
 import com.example.mody.global.common.base.BaseEntity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-
 @Entity(name = "post")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "post")
+@Table(name = "post", indexes = {
+		@Index(name = "idx_bodytype_post",
+				columnList = "body_type_id, post_id"),
+		@Index(name = "idx_member_post",
+				columnList = "member_id, post_id")
+})
 @DynamicUpdate
 public class Post extends BaseEntity {
 

--- a/src/main/java/com/example/mody/domain/post/entity/mapping/MemberPostLike.java
+++ b/src/main/java/com/example/mody/domain/post/entity/mapping/MemberPostLike.java
@@ -1,5 +1,6 @@
 package com.example.mody.domain.post.entity.mapping;
 
+import jakarta.persistence.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -7,15 +8,6 @@ import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.post.entity.Post;
 import com.example.mody.global.common.base.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,7 +21,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @DynamicInsert
 @DynamicUpdate
-@Table(name = "member_post_like")
+@Table(name = "member_post_like", indexes = {
+		@Index(name = "idx_member_post",
+				columnList = "member_id, post_id")
+})
 public class MemberPostLike extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
@@ -2,7 +2,7 @@ package com.example.mody.domain.post.repository;
 
 import com.example.mody.domain.bodytype.entity.BodyType;
 import com.example.mody.domain.member.entity.Member;
-import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.dto.response.PostResponses;
 import com.example.mody.domain.post.dto.response.recode.LikedPostsResponse;
 import com.example.mody.domain.post.entity.Post;
 
@@ -10,10 +10,10 @@ import java.util.Optional;
 
 public interface PostCustomRepository {
 
-    public PostListResponse getBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType);
-    public PostListResponse getOtherBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType);
+    public PostResponses getBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType);
+    public PostResponses getOtherBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType);
     public LikedPostsResponse getLikedPosts(Long cursor, Integer size, Member member);
-    public PostListResponse getMyPosts(Long cursor, Integer size, Member member);
-    public PostListResponse getRecentPosts(Long cursor, Integer size, Member member);
+    public PostResponses getMyPosts(Long cursor, Integer size, Member member);
+    public PostResponses getRecentPosts(Long cursor, Integer size, Member member);
 
 }

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepository.java
@@ -5,13 +5,15 @@ import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.post.dto.response.PostListResponse;
 import com.example.mody.domain.post.dto.response.recode.LikedPostsResponse;
 import com.example.mody.domain.post.entity.Post;
-import jakarta.persistence.EntityManager;
 
 import java.util.Optional;
 
 public interface PostCustomRepository {
 
-    public PostListResponse getPostList(Optional<Post> cursorPost, Integer size, Member member, Optional<BodyType> bodyType);
+    public PostListResponse getBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType);
+    public PostListResponse getOtherBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType);
     public LikedPostsResponse getLikedPosts(Long cursor, Integer size, Member member);
     public PostListResponse getMyPosts(Long cursor, Integer size, Member member);
+    public PostListResponse getRecentPosts(Long cursor, Integer size, Member member);
+
 }

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
@@ -4,7 +4,7 @@ import com.example.mody.domain.bodytype.entity.BodyType;
 import com.example.mody.domain.bodytype.entity.QBodyType;
 import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.member.entity.QMember;
-import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.dto.response.PostResponses;
 import com.example.mody.domain.post.dto.response.PostResponse;
 import com.example.mody.domain.post.dto.response.recode.LikedPostsResponse;
 import com.example.mody.domain.post.entity.Post;
@@ -13,21 +13,15 @@ import com.example.mody.domain.post.entity.QPostImage;
 import com.example.mody.domain.post.entity.mapping.QMemberPostLike;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.group.GroupBy;
-import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
-import com.querydsl.core.types.dsl.StringTemplate;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import jakarta.persistence.QueryHint;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.annotations.QueryHints;
 import org.springframework.stereotype.Repository;
 
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.BiFunction;
 
@@ -54,7 +48,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
      * @return
      */
     @Override
-    public PostListResponse getBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType) {
+    public PostResponses getBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         predicate.and(qPost.isPublic.eq(true)); // 공개여부 == true
@@ -72,12 +66,12 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
         List<PostResponse> postResponses = getPostResponsesByIds(postIds, member, orderSpecifiers);
 
         // 여기서는 목록 개수가 size 개수와 동일한 경우도 hasNext가 true임.
-        return PostListResponse.of(hasNext.apply(postResponses, size-1),
+        return PostResponses.of(hasNext.apply(postResponses, size-1),
                 postResponses.subList(0, Math.min(size, postResponses.size())));
     }
 
     @Override
-    public PostListResponse getOtherBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType) {
+    public PostResponses getOtherBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         predicate.and(qPost.isPublic.eq(true)); // 공개여부 == true
@@ -94,7 +88,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
         List<Long> postIds = getPostIds(predicate, size+1, orderSpecifiers); //하나 더 가져와서 다음 요소가 존재하는지 확인
         List<PostResponse> postResponses = getPostResponsesByIds(postIds, member, orderSpecifiers);
 
-        return PostListResponse.of(hasNext.apply(postResponses, size),
+        return PostResponses.of(hasNext.apply(postResponses, size),
                 postResponses.subList(0, Math.min(size, postResponses.size())));
     }
 
@@ -125,7 +119,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
     }
 
     @Override
-    public PostListResponse getMyPosts(Long cursor, Integer size, Member member) {
+    public PostResponses getMyPosts(Long cursor, Integer size, Member member) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         predicate.and(qPost.member.eq(member));
@@ -140,12 +134,12 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
         List<Long> postIds = getPostIds(predicate, size+1, orderSpecifiers);
         List<PostResponse> postResponses = getPostResponsesByIds(postIds, member, orderSpecifiers);
 
-        return PostListResponse.of(hasNext.apply(postResponses, size),
+        return PostResponses.of(hasNext.apply(postResponses, size),
                 postResponses.subList(0, Math.min(size, postResponses.size())));
     }
 
     @Override
-    public PostListResponse getRecentPosts(Long cursor, Integer size, Member member) {
+    public PostResponses getRecentPosts(Long cursor, Integer size, Member member) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         predicate.and(qPost.isPublic.eq(true));
@@ -160,7 +154,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
         List<Long> postIds = getPostIds(predicate, size+1, orderSpecifiers);
         List<PostResponse> postResponses = getPostResponsesByIds(postIds, member, orderSpecifiers);
 
-        return PostListResponse.of(hasNext.apply(postResponses, size),
+        return PostResponses.of(hasNext.apply(postResponses, size),
                 postResponses.subList(0, Math.min(size, postResponses.size())));
     }
 

--- a/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mody/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.example.mody.domain.post.repository;
 
 import com.example.mody.domain.bodytype.entity.BodyType;
+import com.example.mody.domain.bodytype.entity.QBodyType;
 import com.example.mody.domain.member.entity.Member;
 import com.example.mody.domain.member.entity.QMember;
 import com.example.mody.domain.post.dto.response.PostListResponse;
@@ -20,8 +21,10 @@ import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import jakarta.persistence.QueryHint;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.QueryHints;
 import org.springframework.stereotype.Repository;
 
 import java.time.format.DateTimeFormatter;
@@ -39,6 +42,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
     private final QMember qMember = QMember.member;
     private final QMemberPostLike qMemberPostLike = QMemberPostLike.memberPostLike;
     private final QPostImage qPostImage = QPostImage.postImage;
+    private final QBodyType qBodyType = QBodyType.bodyType;
 
 
     /**
@@ -50,59 +54,45 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
      * @return
      */
     @Override
-    public PostListResponse getPostList(Optional<Post> cursorPost, Integer size, Member member, Optional<BodyType> bodyType) {
+    public PostListResponse getBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         predicate.and(qPost.isPublic.eq(true)); // 공개여부 == true
+        predicate.and(qPost.bodyType.eq(bodyType));
 
         if(cursorPost.isPresent()){
-            String customCursor = createCustomCursor(cursorPost.get(), bodyType);
-            log.info(customCursor);
-            predicate.and(applyCustomCursor(customCursor, bodyType));
-        }
-
-        BooleanExpression isLiked = Expressions.asBoolean(false);
-        if (member != null){
-            isLiked = isLikedResult(member);
+            predicate.and(qPost.id.lt(cursorPost.get().getId()));
         }
 
         //동적 정렬
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
-        if (bodyType.isPresent()) {
-            orderSpecifiers.add(matchedBodyTypeAsInteger(bodyType).desc()); // bodyType이 존재할 때만 정렬 조건 추가
+        orderSpecifiers.add(qPost.id.desc()); // id를 auto_increment 를 사용하므로 created_at을 대신하여 id로 최신순 정렬을 함
+
+        List<Long> postIds = getPostIds(predicate, size, orderSpecifiers);
+        List<PostResponse> postResponses = getPostResponsesByIds(postIds, member, orderSpecifiers);
+
+        // 여기서는 목록 개수가 size 개수와 동일한 경우도 hasNext가 true임.
+        return PostListResponse.of(hasNext.apply(postResponses, size-1),
+                postResponses.subList(0, Math.min(size, postResponses.size())));
+    }
+
+    @Override
+    public PostListResponse getOtherBodyTypePosts(Optional<Post> cursorPost, Integer size, Member member, BodyType bodyType) {
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        predicate.and(qPost.isPublic.eq(true)); // 공개여부 == true
+        predicate.and(qPost.bodyType.ne(bodyType));
+
+        if(cursorPost.isPresent()){
+            predicate.and(qPost.id.lt(cursorPost.get().getId()));
         }
-        orderSpecifiers.add(qPost.createdAt.desc()); // 항상 createdAt으로 정렬
 
-        List<Long> postIds = jpaQueryFactory
-                .select(qPost.id)
-                .from(qPost)
-                .where(predicate)
-                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
-                .limit(size+1) //하나 더 가져와서 다음 요소가 존재하는지 확인
-                .fetch();
+        //동적 정렬
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        orderSpecifiers.add(qPost.id.desc());
 
-        Map<Long, PostResponse> postResponseMap = jpaQueryFactory
-                .from(qPost)
-                .leftJoin(qPost.member, qMember)
-                .leftJoin(qPost.images, qPostImage)
-                .leftJoin(qMemberPostLike).on(qMemberPostLike.post.eq(qPost).and(qMemberPostLike.member.eq(member)))
-                .where(qPost.id.in(postIds))
-                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
-                .transform(GroupBy.groupBy(qPost.id).as(
-                        Projections.constructor(PostResponse.class,
-                                qPost.id,
-                                qMember.id,
-                                qMember.nickname,
-                                qMember.eq(member),
-                                qPost.content,
-                                qPost.isPublic,
-                                qPost.likeCount,
-                                qMemberPostLike.isNotNull(),
-                                qPost.bodyType.name,
-                                GroupBy.list(qPostImage)
-                        )));
-
-        List<PostResponse> postResponses = new ArrayList<>(postResponseMap.values());
+        List<Long> postIds = getPostIds(predicate, size+1, orderSpecifiers); //하나 더 가져와서 다음 요소가 존재하는지 확인
+        List<PostResponse> postResponses = getPostResponsesByIds(postIds, member, orderSpecifiers);
 
         return PostListResponse.of(hasNext.apply(postResponses, size),
                 postResponses.subList(0, Math.min(size, postResponses.size())));
@@ -122,40 +112,12 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
             predicate.and(qMemberPostLike.id.lt(cursor));
         }
 
-        predicate.and(qMemberPostLike.member.eq(member));
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        orderSpecifiers.add(qMemberPostLike.id.desc()); // 최근에 누른 좋아요 순으로 정렬
 
-        List<Long> postIds = jpaQueryFactory
-                .select(qPost.id)
-                .from(qPost)
-                .leftJoin(qMemberPostLike).on(qMemberPostLike.post.eq(qPost).and(qMemberPostLike.member.eq(member)))
-                .where(predicate)
-                .orderBy(qMemberPostLike.createdAt.desc())
-                .limit(size+1) //하나 더 가져와서 다음 요소가 존재하는지 확인
-                .fetch();
-
-        Map<Long, PostResponse> postResponseMap = jpaQueryFactory
-                .from(qPost)
-                .leftJoin(qPost.member, qMember)
-                .leftJoin(qPost.images, qPostImage)
-                .where(qPost.id.in(postIds))
-                .transform(GroupBy.groupBy(qPost.id).as(
-                        Projections.constructor(PostResponse.class,
-                                qPost.id,
-                                qMember.id,
-                                qMember.nickname,
-                                qMember.eq(member),
-                                qPost.content,
-                                qPost.isPublic,
-                                qPost.likeCount,
-                                Expressions.asBoolean(Expressions.TRUE),
-                                qPost.bodyType.name,
-                                GroupBy.list(qPostImage)
-                        )));
-
-        List<PostResponse> postResponses = postIds.stream()
-                .map(postResponseMap::get)
-                .filter(Objects::nonNull)
-                .toList();
+        List<Long> postIds = getMemberLikedPostIds(
+                predicate, size+1, member, orderSpecifiers);
+        List<PostResponse> postResponses = getLikedPostResponsesByIds(postIds, member);
 
         return new LikedPostsResponse(
                 hasNext.apply(postResponses, size),
@@ -172,23 +134,68 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
             predicate.and(qPost.id.lt(cursor));
         }
 
-        log.info(predicate.toString());
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        orderSpecifiers.add(qPost.id.desc());
 
-        List<Long> postIds = jpaQueryFactory
+        List<Long> postIds = getPostIds(predicate, size+1, orderSpecifiers);
+        List<PostResponse> postResponses = getPostResponsesByIds(postIds, member, orderSpecifiers);
+
+        return PostListResponse.of(hasNext.apply(postResponses, size),
+                postResponses.subList(0, Math.min(size, postResponses.size())));
+    }
+
+    @Override
+    public PostListResponse getRecentPosts(Long cursor, Integer size, Member member) {
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        predicate.and(qPost.isPublic.eq(true));
+
+        if(cursor != null){
+            predicate.and(qPost.id.lt(cursor));
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+        orderSpecifiers.add(qPost.id.desc());
+
+        List<Long> postIds = getPostIds(predicate, size+1, orderSpecifiers);
+        List<PostResponse> postResponses = getPostResponsesByIds(postIds, member, orderSpecifiers);
+
+        return PostListResponse.of(hasNext.apply(postResponses, size),
+                postResponses.subList(0, Math.min(size, postResponses.size())));
+    }
+
+    private List<Long> getPostIds(BooleanBuilder predicate, Integer size,
+                                  List<OrderSpecifier<?>> orderSpecifiers){
+        return jpaQueryFactory
                 .select(qPost.id)
                 .from(qPost)
                 .where(predicate)
-                .orderBy(qPost.createdAt.desc())
-                .limit(size+1) //하나 더 가져와서 다음 요소가 존재하는지 확인
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                .limit(size)
                 .fetch();
+    }
 
+    private List<Long> getMemberLikedPostIds(BooleanBuilder predicate, Integer size, Member member,
+                                       List<OrderSpecifier<?>> orderSpecifiers){
+        return jpaQueryFactory
+                .select(qPost.id)
+                .from(qPost)
+                .innerJoin(qMemberPostLike).on(qMemberPostLike.post.eq(qPost).and(qMemberPostLike.member.eq(member)))
+                .where(predicate)
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                .limit(size)
+                .fetch();
+    }
+    private List<PostResponse> getPostResponsesByIds (List<Long> postIds, Member member,
+                                                List<OrderSpecifier<?>> orderSpecifiers){
         Map<Long, PostResponse> postResponseMap = jpaQueryFactory
                 .from(qPost)
-                .leftJoin(qPost.member, qMember)
+                .innerJoin(qPost.member, qMember)
                 .leftJoin(qPost.images, qPostImage)
                 .leftJoin(qMemberPostLike).on(qMemberPostLike.post.eq(qPost).and(qMemberPostLike.member.eq(member)))
+                .innerJoin(qPost.bodyType, qBodyType)
                 .where(qPost.id.in(postIds))
-                .orderBy( qPost.createdAt.desc())
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
                 .transform(GroupBy.groupBy(qPost.id).as(
                         Projections.constructor(PostResponse.class,
                                 qPost.id,
@@ -204,87 +211,40 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                         )));
 
         List<PostResponse> postResponses = new ArrayList<>(postResponseMap.values());
+        return postResponses;
+    }
 
-        return PostListResponse.of(hasNext.apply(postResponses, size),
-                postResponses.subList(0, Math.min(size, postResponses.size())));
+    private List<PostResponse> getLikedPostResponsesByIds (List<Long> postIds, Member member){
+        Map<Long, PostResponse> postResponseMap = jpaQueryFactory
+                .from(qPost)
+                .innerJoin(qPost.member, qMember)
+                .leftJoin(qPost.images, qPostImage)
+                .innerJoin(qPost.bodyType, qBodyType)
+                .where(qPost.id.in(postIds))
+                .transform(GroupBy.groupBy(qPost.id).as(
+                        Projections.constructor(PostResponse.class,
+                                qPost.id,
+                                qMember.id,
+                                qMember.nickname,
+                                qMember.eq(member),
+                                qPost.content,
+                                qPost.isPublic,
+                                qPost.likeCount,
+                                Expressions.asBoolean(Expressions.TRUE),
+                                qPost.bodyType.name,
+                                GroupBy.list(qPostImage)
+                        )));
+
+        return orderByPostIds(postIds, postResponseMap);
+    }
+
+    private List<PostResponse> orderByPostIds(List<Long> postIds, Map<Long, PostResponse> postResponseMap){
+        return postIds.stream()
+                .map(postResponseMap::get)
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     private BiFunction<List<PostResponse> , Integer, Boolean> hasNext = (list, size) -> list.size() > size;
-
-    /**
-     * // 정렬 기준. 특정 바디 타입이 요구되지 않으면 전부 1
-     * @param bodyType
-     * @return
-     */
-    private NumberExpression<Integer> matchedBodyTypeAsInteger(Optional<BodyType> bodyType){
-        if(bodyType.isPresent()){
-            return new CaseBuilder()
-                    .when(qPost.bodyType.eq(bodyType.get())).then(1)
-                    .otherwise(0);
-        }
-        return  Expressions.asNumber(0);
-    }
-
-    private StringExpression matchedBodyTypeAsString(Optional<BodyType> bodyType){
-        if(bodyType.isPresent()){
-            return new CaseBuilder()
-                    .when(qPost.bodyType.eq(bodyType.get())).then("1")
-                    .otherwise("0");
-        }
-        return  Expressions.asString("0");
-    }
-
-    private BooleanExpression isLikedResult(Member member){
-        return JPAExpressions
-                .selectFrom(qMemberPostLike)
-                .where(qMemberPostLike.member.eq(member).and(qMemberPostLike.post.eq(qPost)))
-                .exists();
-    }
-
-    private String createCustomCursor(Post cursor, Optional<BodyType> bodyType){
-        if (cursor == null || bodyType == null) {
-            return null;
-        }
-
-        String isMatchedBodyType = "0";
-        if(bodyType.isPresent()){
-            if(cursor.getBodyType().getId().equals(bodyType.get().getId())){
-                isMatchedBodyType = "1";
-            }
-        }
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-        return isMatchedBodyType + String.format("%19s", formatter.format(cursor.getCreatedAt())).replaceAll(" ","0");
-    }
-
-    /**
-     * createdAt을 'YYYYMMDDHHmmss' 로 변환
-     * @return
-     */
-    private StringTemplate mySqlDateFormat(){
-        return Expressions.stringTemplate(
-                "CAST(DATE_FORMAT({0}, {1}) AS STRING)",
-                qPost.createdAt,
-                ConstantImpl.create("%Y%m%d%H%i%s")
-        );
-    }
-
-    private StringExpression formatCreatedAt(StringTemplate stringTemplate){
-        return StringExpressions.lpad(stringTemplate, 19, '0');
-    }
-
-    private BooleanExpression applyCustomCursor(String customCursor, Optional<BodyType> bodyType) {
-        if (customCursor == null) { // 커서가 없으면 조건 없음
-            return null;
-        }
-
-        // bodyType 순서 계산
-        StringExpression isMatchedBodyType = matchedBodyTypeAsString(bodyType); // bodyType 일치 여부
-        StringTemplate postCreatedAtTemplate = mySqlDateFormat(); //DATE_FORMAT으로 날짜 형태 변경
-        StringExpression formattedCreatedAt = formatCreatedAt(postCreatedAtTemplate); // 날짜 형태 변경을 포맷
-
-        return isMatchedBodyType.concat(formattedCreatedAt)
-                .lt(customCursor);
-    }
 
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryService.java
@@ -1,12 +1,12 @@
 package com.example.mody.domain.post.service;
 
 import com.example.mody.domain.member.entity.Member;
-import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.dto.response.PostResponses;
 import com.example.mody.domain.post.dto.response.PostResponse;
 
 public interface PostQueryService {
-    public PostListResponse getPosts(Member member, Integer size, Long cursor);
-    public PostListResponse getLikedPosts(Member member, Integer size, Long cursor);
-    public PostListResponse getMyPosts(Member member, Integer size, Long cursor);
+    public PostResponses getPosts(Member member, Integer size, Long cursor);
+    public PostResponses getLikedPosts(Member member, Integer size, Long cursor);
+    public PostResponses getMyPosts(Member member, Integer size, Long cursor);
     public PostResponse getPost(Member member, Long postId);
 }

--- a/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/post/service/PostQueryServiceImpl.java
@@ -4,7 +4,7 @@ import com.example.mody.domain.bodytype.entity.BodyType;
 import com.example.mody.domain.bodytype.service.BodyTypeService;
 import com.example.mody.domain.exception.PostException;
 import com.example.mody.domain.member.entity.Member;
-import com.example.mody.domain.post.dto.response.PostListResponse;
+import com.example.mody.domain.post.dto.response.PostResponses;
 import com.example.mody.domain.post.dto.response.PostResponse;
 import com.example.mody.domain.post.dto.response.recode.LikedPostsResponse;
 import com.example.mody.domain.post.entity.Post;
@@ -33,7 +33,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public PostListResponse getPosts(Member member, Integer size, Long cursor) {
+    public PostResponses getPosts(Member member, Integer size, Long cursor) {
         if(size<=0){
             throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
         }
@@ -51,7 +51,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public PostListResponse getLikedPosts(Member member, Integer size, Long cursor) {
+    public PostResponses getLikedPosts(Member member, Integer size, Long cursor) {
         if(size<=0){
             throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
         }
@@ -63,12 +63,12 @@ public class PostQueryServiceImpl implements PostQueryService {
             nextLike = Optional.ofNullable(findByMemberAndPostId(member, postResponse.getPostId()).getId());
         }
 
-        return PostListResponse.of(likedPostsResponse.hasNext(), likedPostsResponse.postResponses(), nextLike.orElse(null));
+        return PostResponses.of(likedPostsResponse.hasNext(), likedPostsResponse.postResponses(), nextLike.orElse(null));
     }
 
     @Override
     @Transactional(readOnly = true)
-    public PostListResponse getMyPosts(Member member, Integer size, Long cursor) {
+    public PostResponses getMyPosts(Member member, Integer size, Long cursor) {
         if(size<=0){
             throw new RestApiException(GlobalErrorStatus.NEGATIVE_PAGE_SIZE_REQUEST);
         }
@@ -101,11 +101,11 @@ public class PostQueryServiceImpl implements PostQueryService {
         return postResponse;
     }
 
-    private PostListResponse getRecentPostResponses(Member member, Integer size, Long cursor){
+    private PostResponses getRecentPostResponses(Member member, Integer size, Long cursor){
         return postRepository.getRecentPosts(cursor, size, member);
     }
 
-    private PostListResponse getPostsByBodyType(
+    private PostResponses getPostsByBodyType(
             Member member, Integer size, Optional<Post> cursorPost, BodyType userBodyType){
         // 커서가 존재하지 않거나(== 최초 조회) 커서 post의 바디타입이 유저의 바디타입과 일치하는 경우
         if(cursorPost.isEmpty() ||
@@ -115,20 +115,20 @@ public class PostQueryServiceImpl implements PostQueryService {
         return getOtherBodyTypePosts(member, size,Optional.empty(), userBodyType);
     }
 
-    private PostListResponse getBodyTypePosts(
+    private PostResponses getBodyTypePosts(
             Member member, Integer size, Optional<Post> cursorPost, BodyType userBodyType){
-        PostListResponse bodyTypePosts = postRepository.getBodyTypePosts(cursorPost, size, member, userBodyType);
+        PostResponses bodyTypePosts = postRepository.getBodyTypePosts(cursorPost, size, member, userBodyType);
 
         int insufficientCount = size - bodyTypePosts.getPostResponses().size();
         if (insufficientCount > 0){
-            PostListResponse otherBodyTypePosts = getOtherBodyTypePosts(
+            PostResponses otherBodyTypePosts = getOtherBodyTypePosts(
                     member, insufficientCount,Optional.empty(), userBodyType);
-            return PostListResponse.of(bodyTypePosts, otherBodyTypePosts);
+            return PostResponses.of(bodyTypePosts, otherBodyTypePosts);
         }
         return bodyTypePosts;
     }
 
-    private PostListResponse getOtherBodyTypePosts(
+    private PostResponses getOtherBodyTypePosts(
             Member member, Integer size, Optional<Post> cursorPost, BodyType userBodyType){
         return postRepository.getOtherBodyTypePosts(cursorPost, size, member, userBodyType);
     }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
Closes #131 

## 📝 요약(Summary)

- 기존 인덱스를 타지 못하던 정렬 기준 수정 
  - created_at 대신 인조 식별자 PK 값으로 정렬 기준을 변경
- 인덱스 사용이 불가했던 커스텀 커서를 사용하지 않고 비즈니스 로직으로 상황별 최적화
- 중복되는 jpaQueryFactory 분리
- 인덱스 추가 
  - post - idx_bodytype_post, idx_member_post 
  - memberPostLike - idx_member_post

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 3차 과제 쿼리 최적화에 관련 내용 정리해놨습니다. 확인하시고 피드백 주시면 감사하겠습니다.

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
