### PR TITLE
🔨 [FIX] #154 - S3 url 이중 인코딩 문제 해결

### DIFF
--- a/src/main/java/com/example/mody/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/mody/domain/member/service/MemberCommandServiceImpl.java
@@ -25,6 +25,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
 
 @Service
 @RequiredArgsConstructor
@@ -125,7 +128,9 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 	private void validateS3Url(String s3Url) {
 		try {
 			// S3 url에 GET 요청을 보내서 유효한지 확인
-			restTemplate.exchange(s3Url, HttpMethod.GET, null, Void.class);
+			// build(true) 사용 -> URL 인코딩된 부분을 그대로 유지
+			URI uri = UriComponentsBuilder.fromHttpUrl(s3Url).build(true).toUri();
+			restTemplate.exchange(uri, HttpMethod.GET, null, Void.class);
 		} catch (HttpClientErrorException e) {
 			throw new RestApiException(S3ErrorStatus.OBJECT_NOT_FOUND);
 		}


### PR DESCRIPTION
## #️⃣ Issue Number

#154 

## 📝 요약(Summary)

* 이미지를 업로드할 때 파일 이름이 한글이면 인코딩이 되어 S3 url 로 반환 됨
* 서버에서 해당 S3 url을 검증할 때 유효한지 GET 요청을 날리는데 이 때 또 인코딩이 되어 유효한 S3 url에도 S3_404 에러가 뜸
* S3 url 유효성을 검증할 때 이중 인코딩이 안 되도록 설정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
